### PR TITLE
Add CI workflow to lint and check formatting of Go code

### DIFF
--- a/.github/workflows/check-go.yml
+++ b/.github/workflows/check-go.yml
@@ -1,0 +1,71 @@
+name: Check Go
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-go.yml"
+      - "Taskfile.yml"
+      - "**.go"
+  pull_request:
+    paths:
+      - ".github/workflows/check-go.yml"
+      - "Taskfile.yml"
+      - "**.go"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to tools.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check-errors:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check for errors
+        run: task go:vet
+
+  check-style:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check style
+        run: task --silent go:lint
+
+  check-formatting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Format code
+        run: task go:format
+
+      - name: Check formatting
+        run: git diff --color --exit-code

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Check Go status](https://github.com/arduino/libraries-repository-engine/actions/workflows/check-go.yml/badge.svg)](https://github.com/arduino/libraries-repository-engine/actions/workflows/check-go.yml)
+
 BUILD
 ----------------------------
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,7 +1,7 @@
 # See: https://taskfile.dev/#/usage
 version: "3"
 
-env:
+vars:
   DEFAULT_GO_PACKAGES:
     sh: echo $(go list ./... | tr '\n' ' ')
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,3 +15,34 @@ tasks:
     desc: Run unit tests
     cmds:
       - go test -v -short -run '{{default ".*" .GO_TEST_REGEX}}' {{default "-timeout 10m -coverpkg=./... -covermode=atomic" .GO_TEST_FLAGS}} -coverprofile=coverage_unit.txt {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
+
+  go:check:
+    desc: Check for problems with Go code
+    deps:
+      - task: go:vet
+      - task: go:lint
+
+  go:vet:
+    desc: Check for errors in Go code
+    cmds:
+      - go vet {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
+
+  go:lint:
+    desc: Lint Go code
+    cmds:
+      - |
+        PROJECT_PATH="$PWD"
+        # `go get` and `go list` commands must be run from a temporary folder to avoid polluting go.mod
+        cd "$(mktemp -d "${TMPDIR-${TMP-/tmp}}/task-temporary-XXXXX")"
+        go get golang.org/x/lint/golint
+        GOLINT_PATH="$(go list -f '{{"{{"}}.Target{{"}}"}}' golang.org/x/lint/golint || echo "false")"
+        # `golint` must be run from the module folder
+        cd "$PROJECT_PATH"
+        "$GOLINT_PATH" \
+          {{default "-min_confidence 0.8 -set_exit_status" .GO_LINT_FLAGS}} \
+          {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
+
+  go:format:
+    desc: Format Go code
+    cmds:
+      - go fmt {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}

--- a/libraries/bad_file_cleaner.go
+++ b/libraries/bad_file_cleaner.go
@@ -15,10 +15,10 @@ func FailIfHasUndesiredFiles(folder string) error {
 	return failIfContainsExes(folder)
 }
 
-var FORBIDDEN_FILES = []string{".development"}
+var ForbiddenFiles = []string{".development"}
 
 func failIfContainsForbiddenFileInRoot(folder string) error {
-	for _, file := range FORBIDDEN_FILES {
+	for _, file := range ForbiddenFiles {
 		if _, err := os.Stat(filepath.Join(folder, file)); err == nil {
 			return errors.New(file + " file found, skipping")
 		}
@@ -27,10 +27,10 @@ func failIfContainsForbiddenFileInRoot(folder string) error {
 	return nil
 }
 
-var PATTERNS = []string{"*.exe"}
+var Patterns = []string{"*.exe"}
 
 func failIfContainsExes(folder string) error {
-	for _, pattern := range PATTERNS {
+	for _, pattern := range Patterns {
 		cmd := exec.Command("find", folder, "-type", "f", "-name", pattern)
 		output, err := cmd.CombinedOutput()
 		if err != nil {

--- a/libraries/bad_file_cleaner.go
+++ b/libraries/bad_file_cleaner.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 )
 
+// FailIfHasUndesiredFiles returns an error if the folder contains any undesired files.
 func FailIfHasUndesiredFiles(folder string) error {
 	err := failIfContainsForbiddenFileInRoot(folder)
 	if err != nil {
@@ -15,6 +16,7 @@ func FailIfHasUndesiredFiles(folder string) error {
 	return failIfContainsExes(folder)
 }
 
+// ForbiddenFiles is the names of the forbidden files.
 var ForbiddenFiles = []string{".development"}
 
 func failIfContainsForbiddenFileInRoot(folder string) error {
@@ -27,6 +29,7 @@ func failIfContainsForbiddenFileInRoot(folder string) error {
 	return nil
 }
 
+// Patterns is the file patterns of executables.
 var Patterns = []string{"*.exe"}
 
 func failIfContainsExes(folder string) error {

--- a/libraries/clamav.go
+++ b/libraries/clamav.go
@@ -31,6 +31,7 @@ func modifyEnv(env []string, key, value string) []string {
 	return envMapToSlice(envMap)
 }
 
+// RunAntiVirus scans the folder for viruses.
 func RunAntiVirus(folder string) ([]byte, error) {
 	cmd := exec.Command("clamdscan", "-i", folder)
 	cmd.Env = modifyEnv(os.Environ(), "LANG", "en")

--- a/libraries/clamav.go
+++ b/libraries/clamav.go
@@ -43,7 +43,7 @@ func RunAntiVirus(folder string) ([]byte, error) {
 
 	output := string(out)
 	if strings.Index(output, "Infected files: 0") == -1 {
-		return out, errors.New("Infected files found!")
+		return out, errors.New("Infected files found")
 	}
 
 	return out, nil

--- a/libraries/cron/fill_missing_checksums.go
+++ b/libraries/cron/fill_missing_checksums.go
@@ -1,10 +1,11 @@
 package cron
 
 import (
-	"arduino.cc/repository/libraries/hash"
 	"io"
 	"net/http"
 	"os"
+
+	"arduino.cc/repository/libraries/hash"
 )
 
 /*

--- a/libraries/cron/fill_missing_checksums.go
+++ b/libraries/cron/fill_missing_checksums.go
@@ -8,8 +8,8 @@ import (
 )
 
 /*
-   Check for missing size and checksum field and fills them
-   by downloading a copy of the file.
+FillMissingChecksumsForDownloadArchives checks for missing size and checksum field and fills them
+by downloading a copy of the file.
 */
 func FillMissingChecksumsForDownloadArchives(URL string, filename string) (int64, string, error) {
 	size, err := download(URL, filename)

--- a/libraries/db/db.go
+++ b/libraries/db/db.go
@@ -55,10 +55,12 @@ type Dependency struct {
 	Version string
 }
 
+// New returns a new DB object.
 func New(libraryFile string) *DB {
 	return &DB{libraryFile: libraryFile}
 }
 
+// AddLibrary adds a library to the database.
 func (db *DB) AddLibrary(library *Library) error {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()
@@ -70,6 +72,7 @@ func (db *DB) AddLibrary(library *Library) error {
 	return nil
 }
 
+// HasLibrary returns whether the database already contains the given library.
 func (db *DB) HasLibrary(libraryName string) bool {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()
@@ -81,6 +84,7 @@ func (db *DB) hasLibrary(libraryName string) bool {
 	return found != nil
 }
 
+// FindLibrary returns the Library object for the given name.
 func (db *DB) FindLibrary(libraryName string) (*Library, error) {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()
@@ -96,6 +100,7 @@ func (db *DB) findLibrary(libraryName string) (*Library, error) {
 	return nil, errors.New("library not found")
 }
 
+// AddRelease adds a library release to the database.
 func (db *DB) AddRelease(release *Release, repoURL string) error {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()
@@ -120,6 +125,7 @@ func (db *DB) AddRelease(release *Release, repoURL string) error {
 	return nil
 }
 
+// HasReleaseByNameVersion returns whether the database contains a release for the given library and version number.
 func (db *DB) HasReleaseByNameVersion(libraryName string, libraryVersion string) bool {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()
@@ -131,6 +137,7 @@ func (db *DB) hasReleaseByNameVersion(libraryName string, libraryVersion string)
 	return found != nil
 }
 
+// HasRelease returns whether the database already contains the given Release object.
 func (db *DB) HasRelease(release *Release) bool {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()
@@ -141,6 +148,7 @@ func (db *DB) hasRelease(release *Release) bool {
 	return db.hasReleaseByNameVersion(release.LibraryName, release.Version.String())
 }
 
+// FindRelease returns the Release object from the database that matches the given object.
 func (db *DB) FindRelease(release *Release) (*Release, error) {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()
@@ -156,6 +164,7 @@ func (db *DB) findReleaseByNameVersion(libraryName string, libraryVersion string
 	return nil, errors.New("library not found")
 }
 
+// LoadFromFile returns a DB object loaded from the given filename.
 func LoadFromFile(filename string) (*DB, error) {
 	file, err := os.Open(filename)
 	if err != nil {
@@ -170,6 +179,7 @@ func LoadFromFile(filename string) (*DB, error) {
 	return db, nil
 }
 
+// Load returns a DB object loaded from the given reader.
 func Load(r io.Reader) (*DB, error) {
 	decoder := json.NewDecoder(r)
 	db := new(DB)
@@ -180,6 +190,7 @@ func Load(r io.Reader) (*DB, error) {
 	return db, nil
 }
 
+// SaveToFile saves the database to a file.
 func (db *DB) SaveToFile() error {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()
@@ -191,6 +202,7 @@ func (db *DB) SaveToFile() error {
 	return db.save(file)
 }
 
+// Save writes the database via the given writer.
 func (db *DB) Save(r io.Writer) error {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()
@@ -222,6 +234,7 @@ func (db *DB) findLatestReleaseOfLibrary(lib *Library) (*Release, error) {
 	return found, nil
 }
 
+// FindReleasesOfLibrary returns the database's releases for the given Library object.
 func (db *DB) FindReleasesOfLibrary(lib *Library) []*Release {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()
@@ -239,10 +252,12 @@ func (db *DB) findReleasesOfLibrary(lib *Library) []*Release {
 	return releases
 }
 
+// Commit saves the database to disk.
 func (db *DB) Commit() error {
 	return db.SaveToFile()
 }
 
+// Init loads a database from file and returns it.
 func Init(libraryFile string) *DB {
 	libs, err := LoadFromFile(libraryFile)
 	if err != nil {

--- a/libraries/db/versioning.go
+++ b/libraries/db/versioning.go
@@ -2,28 +2,34 @@ package db
 
 import "encoding/json"
 
+// Version is the type for library versions.
 type Version struct {
 	version string
 }
 
+// Less returns whether the receiver version is lower than the argument.
 func (version *Version) Less(other Version) (bool, error) {
 	// TODO: apply semantic versioning
 	return version.version < other.version, nil
 }
 
+// String returns the version in string form.
 func (version *Version) String() string {
 	return version.version
 }
 
+// UnmarshalJSON parses the JSON-encoded argument and stores the result in the receiver.
 func (version *Version) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &version.version)
 }
 
+// MarshalJSON returns the JSON encoding of the receiver.
 func (version *Version) MarshalJSON() ([]byte, error) {
 	// Encode version as a string
 	return json.Marshal(version.version)
 }
 
+// VersionFromString parses a string to a Version object.
 func VersionFromString(str string) Version {
 	return Version{version: str}
 }

--- a/libraries/file/SCCS.go
+++ b/libraries/file/SCCS.go
@@ -1,5 +1,6 @@
 package file
 
+// SCCSFiles is a map of folder names used internally by source code control systems.
 var SCCSFiles = map[string]bool{
 	"CVS":  true,
 	"RCS":  true,
@@ -8,6 +9,7 @@ var SCCSFiles = map[string]bool{
 	".hg":  true,
 	".bzr": true}
 
+// IsSCCS returns whether the given string is a folder name used internally by source code control systems.
 func IsSCCS(name string) bool {
 	return SCCSFiles[name]
 }

--- a/libraries/github_release_downloader.go
+++ b/libraries/github_release_downloader.go
@@ -1,12 +1,13 @@
 package libraries
 
 import (
-	"arduino.cc/repository/libraries/hash"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
+
+	"arduino.cc/repository/libraries/hash"
 )
 
 // GithubDownloadRelease downloads GitHub's archive of the release.

--- a/libraries/github_release_downloader.go
+++ b/libraries/github_release_downloader.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 )
 
+// GithubDownloadRelease downloads GitHub's archive of the release.
 func GithubDownloadRelease(repoURL, version string) (string, int64, string, error) {
 	tempfile, err := ioutil.TempFile("", "github")
 	if err != nil {

--- a/libraries/github_release_downloader.go
+++ b/libraries/github_release_downloader.go
@@ -9,16 +9,16 @@ import (
 	"strings"
 )
 
-func GithubDownloadRelease(repoUrl, version string) (string, int64, string, error) {
+func GithubDownloadRelease(repoURL, version string) (string, int64, string, error) {
 	tempfile, err := ioutil.TempFile("", "github")
 	if err != nil {
 		return "", -1, "", err
 	}
 	defer os.Remove(tempfile.Name())
 
-	zipFileUrl := strings.Replace(repoUrl, ".git", "", 1) + "/archive/" + version + ".zip"
+	zipFileURL := strings.Replace(repoURL, ".git", "", 1) + "/archive/" + version + ".zip"
 
-	err = saveUrlIn(zipFileUrl, tempfile)
+	err = saveURLIn(zipFileURL, tempfile)
 	if err != nil {
 		return "", -1, "", err
 	}
@@ -34,10 +34,10 @@ func GithubDownloadRelease(repoUrl, version string) (string, int64, string, erro
 		return "", -1, "", err
 	}
 
-	return zipFileUrl, size, checksum, nil
+	return zipFileURL, size, checksum, nil
 }
 
-func saveUrlIn(url string, tempfile *os.File) error {
+func saveURLIn(url string, tempfile *os.File) error {
 	resp, err := http.Get(url)
 	if err != nil {
 		return err

--- a/libraries/hash/checksumhelper.go
+++ b/libraries/hash/checksumhelper.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-// Calculate hash for the file
+// Checksum calculates the hash for the file.
 func Checksum(filename string) (string, error) {
 	hasher := sha256.New()
 	file, err := os.Open(filename)

--- a/libraries/repoarchive.go
+++ b/libraries/repoarchive.go
@@ -9,6 +9,7 @@ import (
 	"arduino.cc/repository/libraries/zip"
 )
 
+// ZipRepo creates a ZIP archive of the repo folder and returns its path.
 func ZipRepo(repoFolder string, baseFolder string, zipFolderName string) (string, error) {
 	err := os.MkdirAll(baseFolder, os.FileMode(0755))
 	if err != nil {
@@ -23,6 +24,7 @@ func ZipRepo(repoFolder string, baseFolder string, zipFolderName string) (string
 	return absoluteFileName, nil
 }
 
+// ZipFolderName returns the name to use for the folder.
 func ZipFolderName(library *metadata.LibraryMetadata) string {
 	pattern := regexp.MustCompile("[^a-zA-Z0-9]")
 	return pattern.ReplaceAllString(library.Name, "_") + "-" + library.Version

--- a/libraries/repoarchive.go
+++ b/libraries/repoarchive.go
@@ -15,7 +15,7 @@ func ZipRepo(repoFolder string, baseFolder string, zipFolderName string) (string
 		return "", err
 	}
 	absoluteFileName := filepath.Join(baseFolder, zipFolderName+".zip")
-	if err := zip.ZipDirectory(repoFolder, zipFolderName, absoluteFileName); err != nil {
+	if err := zip.Directory(repoFolder, zipFolderName, absoluteFileName); err != nil {
 		os.Remove(absoluteFileName)
 		return "", err
 	}

--- a/libraries/repoclone.go
+++ b/libraries/repoclone.go
@@ -22,6 +22,7 @@ type Repository struct {
 	URL        string
 }
 
+// CloneOrFetch returns a Repository object. If the repository is already present, it is opened. Otherwise, cloned.
 func CloneOrFetch(repoMeta *Repo, folderName string) (*Repository, error) {
 	repo := Repository{
 		FolderPath: folderName,
@@ -64,6 +65,7 @@ func CloneOrFetch(repoMeta *Repo, folderName string) (*Repository, error) {
 	return &repo, err
 }
 
+// GenerateLibraryFromRepo parses a repository and returns the library metadata.
 func GenerateLibraryFromRepo(repo *Repository) (*metadata.LibraryMetadata, error) {
 	bytes, err := ioutil.ReadFile(filepath.Join(repo.FolderPath, "library.properties"))
 	if err != nil {
@@ -88,6 +90,7 @@ func GenerateLibraryFromRepo(repo *Repository) (*metadata.LibraryMetadata, error
 	return library, nil
 }
 
+// UpdateLibrary adds a release to the library database.
 func UpdateLibrary(release *db.Release, repoURL string, libraryDb *db.DB) error {
 	var err error
 

--- a/libraries/repoclone.go
+++ b/libraries/repoclone.go
@@ -25,11 +25,11 @@ type Repository struct {
 func CloneOrFetch(repoMeta *Repo, folderName string) (*Repository, error) {
 	repo := Repository{
 		FolderPath: folderName,
-		URL:        repoMeta.Url,
+		URL:        repoMeta.URL,
 	}
 
 	if _, err := os.Stat(folderName); os.IsNotExist(err) {
-		repo.Repository, err = git.PlainClone(folderName, false, &git.CloneOptions{URL: repoMeta.Url})
+		repo.Repository, err = git.PlainClone(folderName, false, &git.CloneOptions{URL: repoMeta.URL})
 		if err != nil {
 			return nil, err
 		}

--- a/libraries/repoclone_test.go
+++ b/libraries/repoclone_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCloneRepos(t *testing.T) {
-	meta := &Repo{Url: "https://github.com/arduino-libraries/Servo.git"}
+	meta := &Repo{URL: "https://github.com/arduino-libraries/Servo.git"}
 
 	subfolder, err := meta.AsFolder()
 	require.NoError(t, err)

--- a/libraries/repolist.go
+++ b/libraries/repolist.go
@@ -64,10 +64,12 @@ func (_ repoMatcherIfGithub) Match(r string) bool {
 }
 */
 
+// GitURLsError is the type for the unknown or unsupported repositories data.
 type GitURLsError struct {
 	Repos []*Repo
 }
 
+// Repo is the type for the library repository data.
 type Repo struct {
 	URL         string
 	Types       []string
@@ -87,6 +89,7 @@ func (repo *Repo) AsFolder() (string, error) {
 	return folderName, nil
 }
 
+// ReposByURL is the type for the libraries repository data.
 type ReposByURL []*Repo
 
 func (r ReposByURL) Len() int {
@@ -180,6 +183,7 @@ func toListOfUniqueRepos(repos []*Repo) []*Repo {
 	return finalRepos
 }
 
+// ListRepos loads a list from the given filename.
 func ListRepos(reposFilename string) ([]*Repo, error) {
 	repos, err := loadRepoListFromFile(reposFilename)
 	if err != nil {

--- a/libraries/repolist.go
+++ b/libraries/repolist.go
@@ -30,7 +30,7 @@ func loadRepoListFromFile(filename string) ([]*Repo, error) {
 			types := strings.Split(split[1], ",")
 			name := split[2]
 			repos = append(repos, &Repo{
-				Url:         url,
+				URL:         url,
 				Types:       types,
 				LibraryName: name,
 			})
@@ -46,7 +46,7 @@ type repoMatcher interface {
 
 type repoMatcherIfDotGit struct{}
 
-func (_ repoMatcherIfDotGit) Match(url string) bool {
+func (repoMatcherIfDotGit) Match(url string) bool {
 	return strings.Index(url, "https://") == 0 && strings.LastIndex(url, ".git") == len(url)-len(".git")
 }
 
@@ -69,7 +69,7 @@ type GitURLsError struct {
 }
 
 type Repo struct {
-	Url         string
+	URL         string
 	Types       []string
 	LibraryName string
 }
@@ -78,7 +78,7 @@ type Repo struct {
 // For example if the repo URL is https://github.com/example/lib.git this function
 // will return "github.com/example/lib"
 func (repo *Repo) AsFolder() (string, error) {
-	u, err := url.Parse(repo.Url)
+	u, err := url.Parse(repo.URL)
 	if err != nil {
 		return "", err
 	}
@@ -87,24 +87,24 @@ func (repo *Repo) AsFolder() (string, error) {
 	return folderName, nil
 }
 
-type ReposByUrl []*Repo
+type ReposByURL []*Repo
 
-func (r ReposByUrl) Len() int {
+func (r ReposByURL) Len() int {
 	return len(r)
 }
 
-func (r ReposByUrl) Swap(i, j int) {
+func (r ReposByURL) Swap(i, j int) {
 	r[i], r[j] = r[j], r[i]
 }
 
-func (r ReposByUrl) Less(i, j int) bool {
-	return r[i].Url < r[j].Url
+func (r ReposByURL) Less(i, j int) bool {
+	return r[i].URL < r[j].URL
 }
 
 func (err GitURLsError) Error() string {
 	error := bytes.NewBufferString("Following URL are unknown or unsupported git repos:\n")
 	for _, v := range err.Repos {
-		fmt.Fprintln(error, v.Url)
+		fmt.Fprintln(error, v.URL)
 	}
 
 	return error.String()
@@ -114,7 +114,7 @@ func filterReposBy(repos []*Repo, matcher repoMatcher) ([]*Repo, error) {
 	var filtered []*Repo
 	var wrong []*Repo
 	for _, repo := range repos {
-		if matcher.Match(repo.Url) {
+		if matcher.Match(repo.URL) {
 			filtered = append(filtered, repo)
 		} else {
 			wrong = append(wrong, repo)
@@ -171,9 +171,9 @@ func toListOfUniqueRepos(repos []*Repo) []*Repo {
 	var finalRepos []*Repo
 
 	for _, repo := range repos {
-		if _, contains := repoMap[repo.Url]; !contains {
+		if _, contains := repoMap[repo.URL]; !contains {
 			finalRepos = append(finalRepos, repo)
-			repoMap[repo.Url] = repo
+			repoMap[repo.URL] = repo
 		}
 	}
 

--- a/libraries/repolist_test.go
+++ b/libraries/repolist_test.go
@@ -11,33 +11,33 @@ func TestListRepos(t *testing.T) {
 
 	require.Equal(t, 11, len(repos))
 
-	require.Equal(t, "https://github.com/PaulStoffregen/OctoWS2811.git", repos[0].Url)
-	require.Equal(t, "https://github.com/PaulStoffregen/AltSoftSerial.git", repos[1].Url)
+	require.Equal(t, "https://github.com/PaulStoffregen/OctoWS2811.git", repos[0].URL)
+	require.Equal(t, "https://github.com/PaulStoffregen/AltSoftSerial.git", repos[1].URL)
 
-	require.Equal(t, "https://github.com/Cheong2K/ble-sdk-arduino.git", repos[2].Url)
-	require.Equal(t, "https://github.com/arduino-libraries/Bridge.git", repos[3].Url)
-	require.Equal(t, "https://github.com/adafruit/Adafruit_ADS1X15.git", repos[4].Url)
-	require.Equal(t, "https://github.com/adafruit/Adafruit_ADXL345.git", repos[5].Url)
-	require.Equal(t, "https://github.com/adafruit/Adafruit_AHRS.git", repos[6].Url)
-	require.Equal(t, "https://github.com/adafruit/Adafruit_AM2315.git", repos[7].Url)
-	require.Equal(t, "https://github.com/arduino-libraries/Scheduler.git", repos[8].Url)
-	require.Equal(t, "https://github.com/arduino-libraries/SD.git", repos[9].Url)
-	require.Equal(t, "https://github.com/arduino-libraries/Servo.git", repos[10].Url)
+	require.Equal(t, "https://github.com/Cheong2K/ble-sdk-arduino.git", repos[2].URL)
+	require.Equal(t, "https://github.com/arduino-libraries/Bridge.git", repos[3].URL)
+	require.Equal(t, "https://github.com/adafruit/Adafruit_ADS1X15.git", repos[4].URL)
+	require.Equal(t, "https://github.com/adafruit/Adafruit_ADXL345.git", repos[5].URL)
+	require.Equal(t, "https://github.com/adafruit/Adafruit_AHRS.git", repos[6].URL)
+	require.Equal(t, "https://github.com/adafruit/Adafruit_AM2315.git", repos[7].URL)
+	require.Equal(t, "https://github.com/arduino-libraries/Scheduler.git", repos[8].URL)
+	require.Equal(t, "https://github.com/arduino-libraries/SD.git", repos[9].URL)
+	require.Equal(t, "https://github.com/arduino-libraries/Servo.git", repos[10].URL)
 	require.Error(t, err)
 
 	error, ok := err.(GitURLsError)
 	require.True(t, ok)
-	require.Equal(t, "https://github.com/arduino-libraries", error.Repos[0].Url)
-	require.Equal(t, "git@github.com:PaulStoffregen/Audio.git", error.Repos[1].Url)
+	require.Equal(t, "https://github.com/arduino-libraries", error.Repos[0].URL)
+	require.Equal(t, "git@github.com:PaulStoffregen/Audio.git", error.Repos[1].URL)
 }
 
 func TestRepoFolderPathDetermination(t *testing.T) {
-	repo := &Repo{Url: "https://github.com/arduino-libraries/Servo.git"}
+	repo := &Repo{URL: "https://github.com/arduino-libraries/Servo.git"}
 	f, err := repo.AsFolder()
 	require.NoError(t, err)
 	require.Equal(t, "github.com/arduino-libraries/Servo", f)
 
-	repo = &Repo{Url: "https://bitbucket.org/bjoern/arduino_osc"}
+	repo = &Repo{URL: "https://bitbucket.org/bjoern/arduino_osc"}
 	f, err = repo.AsFolder()
 	require.NoError(t, err)
 	require.Equal(t, "bitbucket.org/bjoern/arduino_osc", f)

--- a/libraries/zip/ziphelper.go
+++ b/libraries/zip/ziphelper.go
@@ -12,7 +12,7 @@ import (
 
 // ZipDirectory creates a new zip archive that contains a copy of "rootFolder" into "zipFile".
 // Inside the archive "rootFolder" will be renamed to "zipRootFolderName".
-func ZipDirectory(rootFolder string, zipRootFolderName string, zipFile string) error {
+func Directory(rootFolder string, zipRootFolderName string, zipFile string) error {
 	checks := func(path string, info os.FileInfo, err error) error {
 		info, err = os.Lstat(path)
 		if err != nil {

--- a/libraries/zip/ziphelper.go
+++ b/libraries/zip/ziphelper.go
@@ -10,7 +10,7 @@ import (
 	"arduino.cc/repository/libraries/file"
 )
 
-// ZipDirectory creates a new zip archive that contains a copy of "rootFolder" into "zipFile".
+// Directory creates a new zip archive that contains a copy of "rootFolder" into "zipFile".
 // Inside the archive "rootFolder" will be renamed to "zipRootFolderName".
 func Directory(rootFolder string, zipRootFolderName string, zipFile string) error {
 	checks := func(path string, info os.FileInfo, err error) error {

--- a/libraries/zip/ziphelper_test.go
+++ b/libraries/zip/ziphelper_test.go
@@ -18,7 +18,7 @@ func TestZip(t *testing.T) {
 	require.NoError(t, os.Remove(zipFileName))
 	defer os.RemoveAll(zipFileName)
 
-	err = ZipDirectory("./testzip", "a_zip", zipFileName)
+	err = Directory("./testzip", "a_zip", zipFileName)
 	require.NoError(t, err)
 
 	zipFileReader, err := zip.OpenReader(zipFileName)

--- a/sync_libraries.go
+++ b/sync_libraries.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
+// Config is the type of the engine configuration.
 type Config struct {
 	BaseDownloadURL string
 	LibrariesFolder string

--- a/sync_libraries.go
+++ b/sync_libraries.go
@@ -18,7 +18,7 @@ import (
 )
 
 type Config struct {
-	BaseDownloadUrl string
+	BaseDownloadURL string
 	LibrariesFolder string
 	LogsFolder      string
 	LibrariesDB     string
@@ -179,7 +179,7 @@ func setup(config *Config) {
 }
 
 func syncLibrary(logger *log.Logger, repoMetadata *libraries.Repo, libraryDb *db.DB) {
-	logger.Printf("Scraping %s", repoMetadata.Url)
+	logger.Printf("Scraping %s", repoMetadata.URL)
 
 	repoFolderName, err := repoMetadata.AsFolder()
 	if err != nil {
@@ -282,7 +282,7 @@ func syncLibraryTaggedRelease(logger *log.Logger, repo *libraries.Repository, ta
 		return fmt.Errorf("Error while calculating checksums: %s", err)
 	}
 	release := db.FromLibraryToRelease(library)
-	release.URL = config.BaseDownloadUrl + host + "/" + lib + "/" + zipName + ".zip"
+	release.URL = config.BaseDownloadURL + host + "/" + lib + "/" + zipName + ".zip"
 	release.ArchiveFileName = zipName + ".zip"
 	release.Size = size
 	release.Checksum = checksum


### PR DESCRIPTION
On every push and pull request that affects relevant files, and periodically, lint and check formatting of the
repository's Go module.