### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,7 @@
+---
+name: Bug report
+about: Report problems with the code in this repository.
+title: ""
+labels: "type: imperfection"
+assignees: ""
+---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Learn about the Arduino Library Manager indexer
+    url: https://github.com/arduino/library-registry/blob/main/FAQ.md#arduino-library-manager-faq
+    about: Frequently asked questions about the Library Manager indexer.
+  - name: Support request
+    url: https://forum.arduino.cc/
+    about: We can help you out on the Arduino Forum!

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,7 @@
+---
+name: Feature request
+about: Suggest an improvement for this project.
+title: ""
+labels: "type: enhancement"
+assignees: ""
+---


### PR DESCRIPTION
Although I don't feel that templates themselves have any value for this project, the GitHub template system has some very useful features:

- Template chooser allows redirecting support requests via "Contact Links", and also provides a prominent link to security policy to guide vulnerability disclosures.
- Encouraging the reporter to fit their report into a specific category results in more clarity.
- Automatic labeling according to template choice allows the reporter to do the initial classification.