### PR TITLE
Clean repository after each checkout

### DIFF
--- a/libraries/git_integration_test.go
+++ b/libraries/git_integration_test.go
@@ -47,6 +47,8 @@ func TestUpdateLibraryJson(t *testing.T) {
 		require.NoError(t, err)
 		err = repoTree.Checkout(&git.CheckoutOptions{Hash: *resolvedTag, Force: true})
 		require.NoError(t, err)
+		err = repoTree.Clean(&git.CleanOptions{Dir: true})
+		require.NoError(t, err)
 
 		library, err := GenerateLibraryFromRepo(r)
 		require.NoError(t, err)

--- a/sync_libraries.go
+++ b/sync_libraries.go
@@ -244,6 +244,10 @@ func syncLibraryTaggedRelease(logger *log.Logger, repo *libraries.Repository, ta
 		return fmt.Errorf("Error checking out repo: %s", err)
 	}
 
+	if err = repoTree.Clean(&git.CleanOptions{Dir: true}); err != nil {
+		return fmt.Errorf("Error cleaning repo: %s", err)
+	}
+
 	// Create library metadata from library.properties
 	library, err := libraries.GenerateLibraryFromRepo(repo)
 	if err != nil {


### PR DESCRIPTION
Previously, when checking out a tag, folders that had only existed in the previous tag (e.g., `extras/test` when going from [ArduinoIoTCloud@0.11.0](https://github.com/arduino-libraries/ArduinoIoTCloud/tree/0.11.0/extras) to [ArduinoIotCloud@0.10.0](https://github.com/arduino-libraries/ArduinoIoTCloud/tree/0.10.0/extras)) were left behind as empty, and would pollute the library archives.

So it's necessary to do a clean on the repository after each checkout to remove any untracked objects.

Reference:
https://pkg.go.dev/github.com/go-git/go-git/v5#Worktree.Clean