### PR TITLE
Make test support non-deterministic file ordering in zip

### DIFF
--- a/libraries/zip/ziphelper_test.go
+++ b/libraries/zip/ziphelper_test.go
@@ -27,8 +27,18 @@ func TestZip(t *testing.T) {
 	defer zipFileReader.Close()
 
 	require.Equal(t, 4, len(zipFileReader.File))
-	require.Equal(t, "a_zip/", zipFileReader.File[0].Name)
-	require.Equal(t, "a_zip/testfile.txt", zipFileReader.File[1].Name)
-	require.Equal(t, "a_zip/testfolder/", zipFileReader.File[2].Name)
-	require.Equal(t, "a_zip/testfolder/testfileinfolder.txt", zipFileReader.File[3].Name)
+
+	containsName := func(name string) bool {
+		for _, file := range zipFileReader.File {
+			if file.Name == name {
+				return true
+			}
+		}
+
+		return false
+	}
+	require.True(t, containsName("a_zip/"))
+	require.True(t, containsName("a_zip/testfile.txt"))
+	require.True(t, containsName("a_zip/testfolder/"))
+	require.True(t, containsName("a_zip/testfolder/testfileinfolder.txt"))
 }


### PR DESCRIPTION
Previously, the test required the zip contents to be in a specific order. This is not guaranteed. The important thing is
that the zip contains the expected files, not what order the files happen to be in.