### PR TITLE
Remove job ID prefix from log messages

### DIFF
--- a/sync_libraries.go
+++ b/sync_libraries.go
@@ -109,7 +109,7 @@ func syncLibraries(reposFile string) {
 		log.Println("Started worker...")
 		for job := range jobQueue {
 			buffer := &bytes.Buffer{}
-			logger := log.New(buffer, fmt.Sprintf("JOB %03d - ", job.id), log.LstdFlags|log.LUTC)
+			logger := log.New(buffer, "", log.LstdFlags|log.LUTC)
 			syncLibrary(logger, job.repoMetadata, libraryDb)
 
 			// Output log to file


### PR DESCRIPTION
The logs are now going to be exposed to the library maintainers. These new log consumers will have no interest in the
internal implementation detail of which job ID generated the logs, so that information only represents noise which makes
the logs seem less approachable to the casual reader.

### Before:
(simulated log output from indexing a new release)

<pre>
JOB 000 - 2021/05/13 12:00:50 Scraping https://github.com/arduino-libraries/Servo.git
JOB 000 - 2021/05/13 12:00:50 Checking out tag: 1.0.0
JOB 000 - 2021/05/13 12:00:50 Release Servo:1.0.0 already loaded, skipping
JOB 000 - 2021/05/13 12:00:50 Checking out tag: 1.0.1
JOB 000 - 2021/05/13 12:00:50 Release Servo:1.0.1 already loaded, skipping
JOB 000 - 2021/05/13 12:00:50 Checking out tag: 1.0.2
JOB 000 - 2021/05/13 12:00:50 Release Servo:1.0.2 already loaded, skipping
JOB 000 - 2021/05/13 12:00:50 Checking out tag: 1.0.3
JOB 000 - 2021/05/13 12:00:50 Release Servo:1.0.3 already loaded, skipping
JOB 000 - 2021/05/13 12:00:50 Checking out tag: 1.1.0
JOB 000 - 2021/05/13 12:00:50 Release Servo:1.1.0 already loaded, skipping
JOB 000 - 2021/05/13 12:00:50 Checking out tag: 1.1.1
JOB 000 - 2021/05/13 12:00:50 Release Servo:1.1.1 already loaded, skipping
JOB 000 - 2021/05/13 12:00:50 Checking out tag: 1.1.2
JOB 000 - 2021/05/13 12:00:50 Release Servo:1.1.2 already loaded, skipping
JOB 000 - 2021/05/13 12:00:50 Checking out tag: 1.1.3
JOB 000 - 2021/05/13 12:00:50 Release Servo:1.1.3 already loaded, skipping
JOB 000 - 2021/05/13 12:00:50 Checking out tag: 1.1.4
JOB 000 - 2021/05/13 12:00:50 Release Servo:1.1.4 already loaded, skipping
JOB 000 - 2021/05/13 12:00:50 Checking out tag: 1.1.5
JOB 000 - 2021/05/13 12:00:50 Release Servo:1.1.5 already loaded, skipping
JOB 000 - 2021/05/13 12:00:50 Checking out tag: 1.1.6
JOB 000 - 2021/05/13 12:00:50 Release Servo:1.1.6 already loaded, skipping
JOB 000 - 2021/05/13 12:00:51 Checking out tag: refs/tags/1.1.7
JOB 000 - 2021/05/13 12:00:53 <a href="https://arduino.github.io/arduino-lint/latest/">Arduino Lint</a> has suggestions for possible improvements:
<details><summary>Click to expand Arduino Lint report</summary>
<hr>
Linting library in /home/per/Documents/deleteme/engine/data-new/gitclones/github.com/arduino-libraries/Servo
Rule LP013 result: fail
WARNING: Library name Servo is missing the "Arduino_" prefix. All new official library names must use this prefix.
Rule LD002 result: fail
WARNING: No license file found. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository#detecting-a-license

Finished linting project. Results:
Warning count: 2
Error count: 0
Rules passed: true

-------------------

Linting sketch in /home/per/Documents/deleteme/engine/data-new/gitclones/github.com/arduino-libraries/Servo/examples/Knob

Finished linting project. Results:
Warning count: 0
Error count: 0
Rules passed: true

-------------------

Linting sketch in /home/per/Documents/deleteme/engine/data-new/gitclones/github.com/arduino-libraries/Servo/examples/Sweep

Finished linting project. Results:
Warning count: 0
Error count: 0
Rules passed: true

-------------------

Finished linting projects. Results:
Warning count: 2
Error count: 0
Rules passed: true

<hr>
</details>
JOB 000 - 2021/05/13 12:00:53 path=github.com/arduino-libraries, archivename=Servo-1.1.7

</pre>

### After:

<pre>
2021/05/13 12:00:50 Scraping https://github.com/arduino-libraries/Servo.git
2021/05/13 12:00:50 Checking out tag: 1.0.0
2021/05/13 12:00:50 Release Servo:1.0.0 already loaded, skipping
2021/05/13 12:00:50 Checking out tag: 1.0.1
2021/05/13 12:00:50 Release Servo:1.0.1 already loaded, skipping
2021/05/13 12:00:50 Checking out tag: 1.0.2
2021/05/13 12:00:50 Release Servo:1.0.2 already loaded, skipping
2021/05/13 12:00:50 Checking out tag: 1.0.3
2021/05/13 12:00:50 Release Servo:1.0.3 already loaded, skipping
2021/05/13 12:00:50 Checking out tag: 1.1.0
2021/05/13 12:00:50 Release Servo:1.1.0 already loaded, skipping
2021/05/13 12:00:50 Checking out tag: 1.1.1
2021/05/13 12:00:50 Release Servo:1.1.1 already loaded, skipping
2021/05/13 12:00:50 Checking out tag: 1.1.2
2021/05/13 12:00:50 Release Servo:1.1.2 already loaded, skipping
2021/05/13 12:00:50 Checking out tag: 1.1.3
2021/05/13 12:00:50 Release Servo:1.1.3 already loaded, skipping
2021/05/13 12:00:50 Checking out tag: 1.1.4
2021/05/13 12:00:50 Release Servo:1.1.4 already loaded, skipping
2021/05/13 12:00:50 Checking out tag: 1.1.5
2021/05/13 12:00:50 Release Servo:1.1.5 already loaded, skipping
2021/05/13 12:00:50 Checking out tag: 1.1.6
2021/05/13 12:00:50 Release Servo:1.1.6 already loaded, skipping
2021/05/13 12:00:51 Checking out tag: refs/tags/1.1.7
2021/05/13 12:00:53 <a href="https://arduino.github.io/arduino-lint/latest/">Arduino Lint</a> has suggestions for possible improvements:
<details><summary>Click to expand Arduino Lint report</summary>
<hr>
Linting library in /home/per/Documents/deleteme/engine/data-new/gitclones/github.com/arduino-libraries/Servo
Rule LP013 result: fail
WARNING: Library name Servo is missing the "Arduino_" prefix. All new official library names must use this prefix.
Rule LD002 result: fail
WARNING: No license file found. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository#detecting-a-license

Finished linting project. Results:
Warning count: 2
Error count: 0
Rules passed: true

-------------------

Linting sketch in /home/per/Documents/deleteme/engine/data-new/gitclones/github.com/arduino-libraries/Servo/examples/Knob

Finished linting project. Results:
Warning count: 0
Error count: 0
Rules passed: true

-------------------

Linting sketch in /home/per/Documents/deleteme/engine/data-new/gitclones/github.com/arduino-libraries/Servo/examples/Sweep

Finished linting project. Results:
Warning count: 0
Error count: 0
Rules passed: true

-------------------

Finished linting projects. Results:
Warning count: 2
Error count: 0
Rules passed: true

<hr>
</details>
2021/05/13 12:00:53 path=github.com/arduino-libraries, archivename=Servo-1.1.7

</pre>