### PR TITLE
Display Arduino Lint report for already indexed releases

### DIFF
--- a/libraries/db/db.go
+++ b/libraries/db/db.go
@@ -70,6 +70,7 @@ type Release struct {
 	Checksum        string
 	Includes        []string
 	Dependencies    []*Dependency
+	Log             string
 }
 
 // Dependency is a library dependency


### PR DESCRIPTION
When a library release is indexed, if the validation passes but there are warnings from Arduino Lint, they are displayed
in the logs. This may encourage the library authors to make the suggested improvements so that the next release follows
best practices.

However, once a release has been indexed, validation is skipped on subsequent job runs. Previously, this meant that the
warning report was only displayed during the period between the job run that does the indexing and the next run of the
hourly job, when the log that displayed the warning report was overwritten with one that only stated that the release was already indexed.

Example:
<pre>
2021/05/13 12:00:50 Checking out tag: 1.1.6
2021/05/13 12:00:50 Release Servo:1.1.6 already loaded, skipping
</pre>
So the chances of a library maintainer actually catching the useful warning report was slim.

The solution is to cache the warning report in the database and then print the cached report to the logs on every job
run:
<pre>
2021/05/13 12:00:50 Checking out tag: 1.1.6
2021/05/13 12:00:50 Release Servo:1.1.6 already loaded, skipping
2021/05/13 12:00:53 <a href="https://arduino.github.io/arduino-lint/latest/">Arduino Lint</a> has suggestions for possible improvements:
<details><summary>Click to expand Arduino Lint report</summary>
<hr>
Linting library in /home/per/Documents/deleteme/engine/data-new/gitclones/github.com/arduino-libraries/Servo
Rule LP013 result: fail
WARNING: Library name Servo is missing the "Arduino_" prefix. All new official library names must use this prefix.
Rule LD002 result: fail
WARNING: No license file found. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository#detecting-a-license

Finished linting project. Results:
Warning count: 2
Error count: 0
Rules passed: true

-------------------

Linting sketch in /home/per/Documents/deleteme/engine/data-new/gitclones/github.com/arduino-libraries/Servo/examples/Knob

Finished linting project. Results:
Warning count: 0
Error count: 0
Rules passed: true

-------------------

Linting sketch in /home/per/Documents/deleteme/engine/data-new/gitclones/github.com/arduino-libraries/Servo/examples/Sweep

Finished linting project. Results:
Warning count: 0
Error count: 0
Rules passed: true

-------------------

Finished linting projects. Results:
Warning count: 2
Error count: 0
Rules passed: true

<hr>
</details>
</pre>
