### PR TITLE
Don't display data about archive in log

### DIFF
--- a/sync_libraries.go
+++ b/sync_libraries.go
@@ -315,7 +315,6 @@ func syncLibraryTaggedRelease(logger *log.Logger, repo *libraries.Repository, ta
 	zipName := libraries.ZipFolderName(library)
 	lib := filepath.Base(filepath.Clean(filepath.Join(repo.FolderPath, "..")))
 	host := filepath.Base(filepath.Clean(filepath.Join(repo.FolderPath, "..", "..")))
-	logger.Printf("path=%s/%s, archivename=%s", host, lib, zipName)
 	zipFilePath, err := libraries.ZipRepo(repo.FolderPath, filepath.Join(config.LibrariesFolder, host, lib), zipName)
 	if err != nil {
 		return fmt.Errorf("Error while zipping library: %s", err)


### PR DESCRIPTION
Previously, the log entry for each release indexed during that run ended in a line like:
```
2021/05/13 12:00:53 path=github.com/arduino-libraries, archivename=Servo-1.1.7
```
The logs are now going to be exposed to the library maintainers. These new log consumers will have no interest in the
internal implementation detail of the archive path and filename, so that information only represents noise which makes
the logs seem less approachable to the casual reader. I find that these lines make the logs much more difficult to read.