### PR TITLE
Use short tag names in logs

### DIFF
--- a/libraries/repoclone.go
+++ b/libraries/repoclone.go
@@ -27,7 +27,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"arduino.cc/repository/libraries/db"
 
@@ -75,7 +74,7 @@ func CloneOrFetch(repoMeta *Repo, folderName string) (*Repository, error) {
 			break
 		}
 
-		if err = repo.Repository.DeleteTag(strings.TrimPrefix(tag.Name().String(), "refs/tags/")); err != nil {
+		if err = repo.Repository.DeleteTag(tag.Name().Short()); err != nil {
 			return nil, err
 		}
 	}

--- a/sync_libraries.go
+++ b/sync_libraries.go
@@ -250,7 +250,7 @@ func syncLibrary(logger *log.Logger, repoMetadata *libraries.Repo, libraryDb *db
 
 func syncLibraryTaggedRelease(logger *log.Logger, repo *libraries.Repository, tag *plumbing.Reference, repoMeta *libraries.Repo, libraryDb *db.DB) error {
 	// Checkout desired tag
-	logger.Printf("Checking out tag: %s", tag.Name())
+	logger.Printf("Checking out tag: %s", tag.Name().Short())
 
 	repoTree, err := repo.Repository.Worktree()
 	if err != nil {


### PR DESCRIPTION
There was a regression when switching to using `github.com/go-git/go-git`. Originally, the logs used short tag names:
```
2021/05/13 12:00:50 Checking out tag: 1.1.6
```
but after, the long name:
```
2021/05/13 12:00:50 Checking out tag: refs/tags/1.1.6
```
This commit restores it back to the previous way of representing tag names in the log.