### PR TITLE
Add Arduino Lint installation path as a configuration field

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -4,5 +4,6 @@
   "LibrariesIndex": "/tmp/libraries/library_index.json",
   "LibrariesDB": "/tmp/libraries_db.json",
   "GitClonesFolder": "/tmp/gitclones",
+  "ArduinoLintPath": "/usr/bin/arduino-lint",
   "CronTabEntry": "0 0 0 * * *"
 }

--- a/libraries/lint.go
+++ b/libraries/lint.go
@@ -49,7 +49,12 @@ func official(metadata *Repo) bool {
 }
 
 // RunArduinoLint runs Arduino Lint on the library and returns the report in the event of error or warnings.
-func RunArduinoLint(folder string, metadata *Repo) ([]byte, error) {
+func RunArduinoLint(arduinoLintPath string, folder string, metadata *Repo) ([]byte, error) {
+	if arduinoLintPath == "" {
+		// Assume Arduino Lint is installed under PATH.
+		arduinoLintPath = "arduino-lint"
+	}
+
 	JSONReportFolder, err := ioutil.TempDir("", "arduino-lint-report-")
 	if err != nil {
 		panic(err)
@@ -59,7 +64,7 @@ func RunArduinoLint(folder string, metadata *Repo) ([]byte, error) {
 
 	// See: https://arduino.github.io/arduino-lint/latest/commands/arduino-lint/
 	cmd := exec.Command(
-		"arduino-lint",
+		arduinoLintPath,
 		"--compliance=permissive",
 		"--format=text",
 		"--project-type=library",

--- a/libraries/lint_test.go
+++ b/libraries/lint_test.go
@@ -101,7 +101,7 @@ func TestRunArduinoLint(t *testing.T) {
 		} else {
 			metadata.Types = []string{"Contributed"}
 		}
-		report, err := RunArduinoLint(filepath.Join(testDataPath, "libraries", testTable.folder), &metadata)
+		report, err := RunArduinoLint("", filepath.Join(testDataPath, "libraries", testTable.folder), &metadata)
 		assert.Regexp(t, regexp.MustCompile(testTable.reportRegexp), string(report), testTable.testName)
 		testTable.errorAssertion(t, err, testTable.testName)
 	}

--- a/sync_libraries.go
+++ b/sync_libraries.go
@@ -49,6 +49,7 @@ type Config struct {
 	LibrariesIndex  string
 	GitClonesFolder string
 	DoNotRunClamav  bool
+	ArduinoLintPath string
 }
 
 func logError(err error) bool {
@@ -308,7 +309,7 @@ func syncLibraryTaggedRelease(logger *log.Logger, repo *libraries.Repository, ta
 		}
 	}
 
-	report, err := libraries.RunArduinoLint(repo.FolderPath, repoMeta)
+	report, err := libraries.RunArduinoLint(config.ArduinoLintPath, repo.FolderPath, repoMeta)
 	reportTemplate := `<a href="https://arduino.github.io/arduino-lint/latest/">Arduino Lint</a> %s:
 <details><summary>Click to expand Arduino Lint report</summary>
 <hr>


### PR DESCRIPTION
Previously, it was assumed that Arduino Lint was installed somewhere under PATH. That may not be convenient under some
circumstances, so the ability is added to set the path to the arduino-lint executable via the configuration file's
`ArduinoLintPath` key. If the configuration is not provided, the previous behavior is used.