### PR TITLE
Remove unused `CronTabEntry` key from example configuration file

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -4,6 +4,5 @@
   "LibrariesIndex": "/tmp/libraries/library_index.json",
   "LibrariesDB": "/tmp/libraries_db.json",
   "GitClonesFolder": "/tmp/gitclones",
-  "ArduinoLintPath": "/usr/bin/arduino-lint",
-  "CronTabEntry": "0 0 0 * * *"
+  "ArduinoLintPath": "/usr/bin/arduino-lint"
 }


### PR DESCRIPTION
This configuration setting is not used in any way by the engine code. The Jenkins job does not use it and I don't find
any other indication of its use. So it only serves to confuse.