### PR TITLE
Add --fdpass flag to clamdscan command 

### DIFF
--- a/libraries/clamav.go
+++ b/libraries/clamav.go
@@ -56,7 +56,7 @@ func modifyEnv(env []string, key, value string) []string {
 
 // RunAntiVirus scans the folder for viruses.
 func RunAntiVirus(folder string) ([]byte, error) {
-	cmd := exec.Command("clamdscan", "-i", folder)
+	cmd := exec.Command("clamdscan", "--fdpass", "-i", folder)
 	cmd.Env = modifyEnv(os.Environ(), "LANG", "en")
 
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
Antivirus scan performed with clamav on downloaded repos was failing due to the following error:

```
2021/05/21 11:30:51 Error syncing library: exit status 2
2021/05/21 11:30:51 Checking out tag: 1.0.2
2021/05/21 11:30:51 clamav output:
/home/arduino/workspace/workspace/Librariesv2/gitclones/github.com/arduino-libraries/Servo: lstat() failed: Permission denied. ERROR
```
This permission issue was solved taking a look to the [clamdscan man](https://linux.die.net/man/1/clamdscan)

>--fdpass
Pass the file descriptor permissions to clamd. This is useful if clamd is running as a different user as it is faster than streaming the file to clamd. Only available if connected to clamd via local(unix) socket.