### PR TITLE
Remove obsolete comments from source code

### DIFF
--- a/libraries/db/library.go
+++ b/libraries/db/library.go
@@ -70,7 +70,6 @@ var re = regexp.MustCompile("^([a-zA-Z0-9](?:[a-zA-Z0-9._\\- ]*[a-zA-Z0-9])?) *(
 
 // ExtractDependenciesList extracts dependencies from the "depends" field of library.properties
 func ExtractDependenciesList(depends string) ([]*Dependency, error) {
-	// TODO: merge this method with metadata.IsValidDependency
 	deps := []*Dependency{}
 	depends = strings.TrimSpace(depends)
 	if depends == "" {

--- a/libraries/metadata/metadata.go
+++ b/libraries/metadata/metadata.go
@@ -27,11 +27,6 @@ Package metadata handles library.properties metadata.
 The functions in this package helps on parsing/validation of
 library.properties metadata. All metadata are parsed into a
 LibraryMetadata structure.
-
-The source of may be any of the following:
-- a github.PullRequest
-- a github.RepositoryContent
-- a byte[]
 */
 package metadata
 


### PR DESCRIPTION
These comments refer to code that has been removed or replaced (https://github.com/arduino/libraries-repository-engine/pull/32), and so are no longer of any relevance.