### PR TITLE
Add convenience tasks to taskfile

### DIFF
--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -1,0 +1,53 @@
+name: Check Taskfiles
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-taskfiles.ya?ml"
+      - "**/Taskfile.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/check-taskfiles.ya?ml"
+      - "**/Taskfile.ya?ml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    name: Validate ${{ matrix.file }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        file:
+          - ./Taskfile.yml
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download JSON schema for Taskfiles
+        id: download-schema
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/taskfile.json
+          file-url: https://json.schemastore.org/taskfile.json
+          location: ${{ runner.temp }}/taskfile-schema
+          file-name: taskfile.json
+
+      - name: Install JSON schema validator
+        run: sudo npm install --global ajv-cli
+
+      - name: Validate ${{ matrix.file }}
+        run: |
+          # See: https://github.com/ajv-validator/ajv-cli#readme
+          ajv validate \
+            --strict=false \
+            -s "${{ steps.download-schema.outputs.file-path }}" \
+            -d "${{ matrix.file }}"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Test Go status](https://github.com/arduino/libraries-repository-engine/actions/workflows/test-go.yml/badge.svg)](https://github.com/arduino/libraries-repository-engine/actions/workflows/test-go.yml)
 [![Check Go status](https://github.com/arduino/libraries-repository-engine/actions/workflows/check-go.yml/badge.svg)](https://github.com/arduino/libraries-repository-engine/actions/workflows/check-go.yml)
 [![Check Prettier Formatting status](https://github.com/arduino/libraries-repository-engine/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/arduino/libraries-repository-engine/actions/workflows/check-prettier-formatting-task.yml)
+[![Check Taskfiles status](https://github.com/arduino/libraries-repository-engine/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/arduino/libraries-repository-engine/actions/workflows/check-taskfiles.yml)
 [![Spell Check status](https://github.com/arduino/libraries-repository-engine/actions/workflows/spell-check-task.yml/badge.svg)](https://github.com/arduino/libraries-repository-engine/actions/workflows/spell-check-task.yml)
 [![Check License status](https://github.com/arduino/libraries-repository-engine/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/libraries-repository-engine/actions/workflows/check-license.yml)
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,6 +6,25 @@ vars:
     sh: echo $(go list ./... | tr '\n' ' ')
 
 tasks:
+  build:
+    desc: Build the project
+    deps:
+      - task: go:build
+
+  check:
+    desc: Check for problems with the project
+    deps:
+      - task: general:check-spelling
+      - task: go:lint
+      - task: go:test
+      - task: go:vet
+
+  format:
+    desc: Correct the formatting of the project's files
+    deps:
+      - task: general:format-prettier
+      - task: go:format
+
   go:build:
     desc: Build the project
     cmds:


### PR DESCRIPTION
The idea is to have standardized "umbrella" tasks which group together related framework-specific tasks and are present in every [Task](https://taskfile.dev/#/)-based project.