### PR TITLE
Configure Dependabot for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,9 @@ updates:
       interval: daily
     labels:
       - "topic: infrastructure"
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"


### PR DESCRIPTION
With the introduction of Python-based integration tests, the Python dependencies of the project become more significant.
Since we already have the Dependabot infrastructure in place for managing dependencies of the project's Go code and
GitHub Actions workflows, it makes sense to do the same for the Python dependencies as well.

Reference:
https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#about-the-dependabotyml-file