### PR TITLE
Distribute release binary in an archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "ARCHIVE_PATH=${{ runner.temp }}/libraries-repository-engine_Linux_64bit.tar.gz" >> "$GITHUB_ENV"
           echo "CHANGELOG_PATH=${{ runner.temp }}/CHANGELOG.md" >> "$GITHUB_ENV"
 
       - name: Checkout repository
@@ -33,6 +34,15 @@ jobs:
 
       - name: Build project
         run: task build
+
+      - name: Archive release binary
+        run: |
+          tar \
+            --create \
+            --add-file="./libraries-repository-engine" \
+            --add-file="./LICENSE.txt" \
+            --gzip \
+            --file="${{ env.ARCHIVE_PATH }}"
 
       - name: Create changelog
         uses: arduino/create-changelog@v1
@@ -63,4 +73,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           bodyFile: ${{ env.CHANGELOG_PATH }}
           prerelease: ${{ steps.prerelease.outputs.is-pre }}
-          artifacts: libraries-repository-engine
+          artifacts: ${{ env.ARCHIVE_PATH }}


### PR DESCRIPTION
The release workflow builds the tool and uploads the binary as a release asset. That asset is used by the indexer job and
also may be convenient to those who would like to test the release without setting up a build system locally.

Previously, the binary was uploaded directly to the release. This caused the executable permissions to be lost, causing
inconvenience and potential confusion for the consumers. This can be avoided by packaging the binary in an archive. As an
added benefit, the download size is decreased.