### PR TITLE
Use tag name in release asset filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "ARCHIVE_PATH=${{ runner.temp }}/libraries-repository-engine_Linux_64bit.tar.gz" >> "$GITHUB_ENV"
+          TAG_SHORT_NAME="${GITHUB_REF/refs\/tags\//}"
+          echo "TAG_SHORT_NAME=$TAG_SHORT_NAME" >> "$GITHUB_ENV"
+          echo "ARCHIVE_PATH=${{ runner.temp }}/libraries-repository-engine_${TAG_SHORT_NAME}_Linux_64bit.tar.gz" >> "$GITHUB_ENV"
           echo "CHANGELOG_PATH=${{ runner.temp }}/CHANGELOG.md" >> "$GITHUB_ENV"
 
       - name: Checkout repository
@@ -63,7 +65,7 @@ jobs:
           wget --quiet --directory-prefix="$INSTALL_PATH" https://github.com/fsaintjacques/semver-tool/archive/${{ env.TOOL_VERSION }}.zip
           unzip -p "${INSTALL_PATH}/${{ env.TOOL_VERSION }}.zip" semver-tool-${{ env.TOOL_VERSION }}/src/semver >"${INSTALL_PATH}/semver"
           chmod +x "${INSTALL_PATH}/semver"
-          if [[ $("${INSTALL_PATH}/semver" get prerel "${GITHUB_REF/refs\/tags\//}") ]]; then
+          if [[ $("${INSTALL_PATH}/semver" get prerel "${{ env.TAG_SHORT_NAME }}") ]]; then
             echo "::set-output name=is-pre::true";
           fi
 


### PR DESCRIPTION
Previously the release asset archive that contains the pre-built `libraries-repository-engine` binary was named like:
````
libraries-repository-engine_Linux_64bit.tar.gz
````
This was inconsistent with the standard established in other Arduino tooling projects, so it should be changed to follow the standard convention of having the tag name in the archive file name:
```
libraries-repository-engine_0.0.2_Linux_64bit.tar.gz
```