### PR TITLE
Fixed lint warning

### DIFF
--- a/internal/libraries/db/db.go
+++ b/internal/libraries/db/db.go
@@ -234,7 +234,7 @@ func (db *DB) Save(r io.Writer) error {
 }
 
 func (db *DB) save(r io.Writer) error {
-	buff, err := json.MarshalIndent(*db, "", "  ")
+	buff, err := json.MarshalIndent(db, "", "  ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I did not test this PR, but it should write the DB without extra copying.

This solves the warning:
```
# arduino.cc/repository/internal/libraries/db
internal/libraries/db/db.go:237:34: call of json.MarshalIndent copies lock value: arduino.cc/repository/internal/libraries/db.DB contains sync.Mutex
```