### PR TITLE
Add schedule trigger event to integration test workflow

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -22,6 +22,9 @@ on:
       - "poetry.lock"
       - "pyproject.toml"
       - "test/**"
+  schedule:
+    # Run daily at 8 AM UTC to catch breakage resulting from changes to Arduino Lint.
+    - cron: "0 8 * * *"
   workflow_dispatch:
     inputs:
       arduino-lint-ref:


### PR DESCRIPTION
The integration tests use the latest release of Arduino Lint. This means that changes in Arduino Lint can cause an integration test failure independent from any change in this repository. Without a schedule trigger, this might only be noticed as an irrelevant CI failure for the next PR that is submitted (e.g., https://github.com/arduino/libraries-repository-engine/pull/60), which can cause confusion and inconvenience to the contributor.

[A `schedule` trigger](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule) allows the breakage to be identified and resolved early.