### PR TITLE
Allow specifying Arduino Lint ref for manual run of integration test

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -57,7 +57,7 @@ jobs:
           BINDIR="$ARDUINO_LINT_INSTALLATION_PATH" \
           sh
 
-          # Add installation folder to path to path
+          # Add installation folder to path
           echo "$ARDUINO_LINT_INSTALLATION_PATH" >> "$GITHUB_PATH"
 
       - name: Install Taskfile

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -23,11 +23,18 @@ on:
       - "pyproject.toml"
       - "test/**"
   workflow_dispatch:
+    inputs:
+      arduino-lint-ref:
+        description: Arduino Lint ref (leave empty for latest release)
+        default: ""
   repository_dispatch:
 
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    env:
+      ARDUINO_LINT_SOURCE_PATH: arduino-lint
 
     steps:
       - name: Checkout repository
@@ -46,7 +53,14 @@ jobs:
       - name: Install Poetry
         run: pip install poetry
 
-      - name: Install Arduino Lint
+      - name: Install Taskfile
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Install latest release of Arduino Lint
+        if: github.event.inputs.arduino-lint-ref == ''
         run: |
           ARDUINO_LINT_INSTALLATION_PATH="${{ runner.temp }}/arduino-lint"
           mkdir --parents "$ARDUINO_LINT_INSTALLATION_PATH"
@@ -60,11 +74,21 @@ jobs:
           # Add installation folder to path
           echo "$ARDUINO_LINT_INSTALLATION_PATH" >> "$GITHUB_PATH"
 
-      - name: Install Taskfile
-        uses: arduino/setup-task@v1
+      - name: Checkout Arduino Lint repository
+        if: github.event.inputs.arduino-lint-ref != ''
+        uses: actions/checkout@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          repository: arduino/arduino-lint
+          ref: ${{ github.event.inputs.arduino-lint-ref }}
+          path: ${{ env.ARDUINO_LINT_SOURCE_PATH }}
+
+      - name: Build Arduino Lint
+        if: github.event.inputs.arduino-lint-ref != ''
+        working-directory: ${{ env.ARDUINO_LINT_SOURCE_PATH }}
+        run: |
+          task build
+          # Add installation folder to path
+          echo "$PWD" >> "$GITHUB_PATH"
 
       - name: Run integration tests
         run: task go:test-integration


### PR DESCRIPTION
When triggered automatically by a push, PR, or schedule event, the integration test uses the latest release of Arduino Lint. That is the same version used by the production engine, so appropriate for testing development on the engine.

However, the integration of Arduino Lint into the engine should also be tested before a new version is released to be immediately used by the production engine. This will be made easier by allowing the integration test to be run via [a manual trigger](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch) of the GitHub Actions workflow, specifying any arbitrary Git ref of the Arduino Lint repository to build from.

![image](https://user-images.githubusercontent.com/8572152/128809252-03c93d53-c70a-4dc2-8855-02c70358afa3.png)

---
Demonstration runs:
- [`4674bc7e58ba4fc619d035274a54a570c35aa0cd`](https://github.com/arduino/arduino-lint/tree/4674bc7e58ba4fc619d035274a54a570c35aa0cd) as input: https://github.com/per1234/libraries-repository-engine/runs/3287322201?check_suite_focus=true#step:8:4
- `main` as input: https://github.com/per1234/libraries-repository-engine/runs/3287298343?check_suite_focus=true#step:8:4
- empty input: https://github.com/per1234/libraries-repository-engine/runs/3287282633