### PR TITLE
Sync "Check License" CI workflow with template

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Check license file
         run: |
+          EXIT_STATUS=0
           # See: https://github.com/licensee/licensee
           LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
 
@@ -53,12 +54,14 @@ jobs:
           echo "Detected license file: $DETECTED_LICENSE_FILE"
           if [ "$DETECTED_LICENSE_FILE" != "\"$EXPECTED_LICENSE_FILENAME\"" ]; then
             echo "ERROR: detected license file doesn't match expected: $EXPECTED_LICENSE_FILENAME"
-            exit 1
+            EXIT_STATUS=1
           fi
 
           DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
           echo "Detected license type: $DETECTED_LICENSE_TYPE"
           if [ "$DETECTED_LICENSE_TYPE" != "\"$EXPECTED_LICENSE_TYPE\"" ]; then
             echo "ERROR: detected license type doesn't match expected $EXPECTED_LICENSE_TYPE"
-            exit 1
+            EXIT_STATUS=1
           fi
+
+          exit $EXIT_STATUS

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -53,14 +53,14 @@ jobs:
           DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
           echo "Detected license file: $DETECTED_LICENSE_FILE"
           if [ "$DETECTED_LICENSE_FILE" != "\"${EXPECTED_LICENSE_FILENAME}\"" ]; then
-            echo "ERROR: detected license file doesn't match expected: $EXPECTED_LICENSE_FILENAME"
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: $EXPECTED_LICENSE_FILENAME"
             EXIT_STATUS=1
           fi
 
           DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
           echo "Detected license type: $DETECTED_LICENSE_TYPE"
           if [ "$DETECTED_LICENSE_TYPE" != "\"${EXPECTED_LICENSE_TYPE}\"" ]; then
-            echo "ERROR: detected license type doesn't match expected $EXPECTED_LICENSE_TYPE"
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${EXPECTED_LICENSE_TYPE}\""
             EXIT_STATUS=1
           fi
 

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -52,14 +52,14 @@ jobs:
 
           DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
           echo "Detected license file: $DETECTED_LICENSE_FILE"
-          if [ "$DETECTED_LICENSE_FILE" != "\"$EXPECTED_LICENSE_FILENAME\"" ]; then
+          if [ "$DETECTED_LICENSE_FILE" != "\"${EXPECTED_LICENSE_FILENAME}\"" ]; then
             echo "ERROR: detected license file doesn't match expected: $EXPECTED_LICENSE_FILENAME"
             EXIT_STATUS=1
           fi
 
           DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
           echo "Detected license type: $DETECTED_LICENSE_TYPE"
-          if [ "$DETECTED_LICENSE_TYPE" != "\"$EXPECTED_LICENSE_TYPE\"" ]; then
+          if [ "$DETECTED_LICENSE_TYPE" != "\"${EXPECTED_LICENSE_TYPE}\"" ]; then
             echo "ERROR: detected license type doesn't match expected $EXPECTED_LICENSE_TYPE"
             EXIT_STATUS=1
           fi


### PR DESCRIPTION
We have assembled a collection of reusable GitHub Actions workflows:
https://github.com/arduino/tooling-project-assets
These workflows will be used in the repositories of all Arduino tooling projects.

Some minor improvements and standardizations have been made in the upstream "template" workflow for checking the license file, and those are introduced to this repository via this pull request.