### PR TITLE
Add multi-module support to project infrastructure

### DIFF
--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -10,15 +10,15 @@ on:
     paths:
       - ".github/workflows/check-go-task.yml"
       - "Taskfile.yml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "**.go"
   pull_request:
     paths:
       - ".github/workflows/check-go-task.yml"
       - "Taskfile.yml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "**.go"
   schedule:
     # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to tools.
@@ -28,7 +28,15 @@ on:
 
 jobs:
   check-errors:
+    name: check-errors (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -46,10 +54,20 @@ jobs:
           version: 3.x
 
       - name: Check for errors
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:vet
 
   check-outdated:
+    name: check-outdated (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -67,13 +85,23 @@ jobs:
           version: 3.x
 
       - name: Modernize usages of outdated APIs
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:fix
 
       - name: Check if any fixes were needed
         run: git diff --color --exit-code
 
   check-style:
+    name: check-style (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -94,10 +122,20 @@ jobs:
         run: go install golang.org/x/lint/golint@latest
 
       - name: Check style
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task --silent go:lint
 
   check-formatting:
+    name: check-formatting (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -115,13 +153,23 @@ jobs:
           version: 3.x
 
       - name: Format code
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:format
 
       - name: Check formatting
         run: git diff --color --exit-code
 
   check-config:
+    name: check-config (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -133,6 +181,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Run go mod tidy
+        working-directory: ${{ matrix.module.path }}
         run: go mod tidy
 
       - name: Check whether any tidying was needed

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -10,16 +10,16 @@ on:
   push:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "Taskfile.ya?ml"
       - "**/testdata/**"
       - "**.go"
   pull_request:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "Taskfile.ya?ml"
       - "**/testdata/**"
       - "**.go"
@@ -56,7 +56,18 @@ jobs:
           name: libraries-repository-engine
 
   test:
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.module.path }} - ${{ matrix.operating-system }})
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        operating-system:
+          - ubuntu-latest
+        module:
+          - path: ./
+
+    runs-on: ${{ matrix.operating-system }}
 
     steps:
       - name: Checkout repository
@@ -88,4 +99,6 @@ jobs:
           version: 3.x
 
       - name: Run tests
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:test

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,8 +2,11 @@
 version: "3"
 
 vars:
+  # Path of the project's primary Go module:
+  DEFAULT_GO_MODULE_PATH: ./
   DEFAULT_GO_PACKAGES:
-    sh: echo $(go list ./... | tr '\n' ' ')
+    sh: |
+      echo $(cd {{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}} && go list ./... | tr '\n' ' ' || echo '"ERROR: Unable to discover Go packages"')
 
 tasks:
   build:
@@ -31,12 +34,14 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/go-task/Taskfile.yml
   go:build:
     desc: Build the Go code
+    dir: "{{.DEFAULT_GO_MODULE_PATH}}"
     cmds:
       - go build -v -o libraries-repository-engine{{exeExt}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-go-task/Taskfile.yml
   go:test:
     desc: Run unit tests
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - go test -v -short -run '{{default ".*" .GO_TEST_REGEX}}' {{default "-timeout 10m -coverpkg=./... -covermode=atomic" .GO_TEST_FLAGS}} -coverprofile=coverage_unit.txt {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
@@ -58,18 +63,21 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:vet:
     desc: Check for errors in Go code
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - go vet {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:fix:
     desc: Modernize usages of outdated APIs
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - go fix {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:lint:
     desc: Lint Go code
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - |
         if ! which golint &>/dev/null; then
@@ -84,6 +92,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:format:
     desc: Format Go code
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - go fmt {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 


### PR DESCRIPTION
Projects may contain multiple Go modules in subfolders of the repository. In order to support checks on these modules,
it's necessary to configure the commands to run from their path. This is passed to the task via the GO_MODULE_PATH
environment variable. If this variable is not defined, the default root module path is used as default, preserving the
previous task behavior.

The workflows use a job matrix to allow easy configuration for any number of module paths and a dedicated parallel job
for each module.

Although this particular repository does not contain multiple modules, at the moment, and though there may be no plans to
add them at the moment, these are intended to be general-purpose assets that can be applied to any project. Since other
projects do contain multiple modules, the capability is necessary and this project inherits such.