### PR TITLE
Make dedicated package for release archive handling

### DIFF
--- a/internal/command/sync/sync.go
+++ b/internal/command/sync/sync.go
@@ -37,6 +37,7 @@ import (
 	"github.com/arduino/libraries-repository-engine/internal/configuration"
 	"github.com/arduino/libraries-repository-engine/internal/feedback"
 	"github.com/arduino/libraries-repository-engine/internal/libraries"
+	"github.com/arduino/libraries-repository-engine/internal/libraries/archive"
 	"github.com/arduino/libraries-repository-engine/internal/libraries/db"
 	"github.com/arduino/libraries-repository-engine/internal/libraries/gitutils"
 	"github.com/arduino/libraries-repository-engine/internal/libraries/hash"
@@ -268,10 +269,10 @@ func syncLibraryTaggedRelease(logger *log.Logger, repo *libraries.Repository, ta
 		releaseLog += formattedReport
 	}
 
-	zipName := libraries.ZipFolderName(library)
+	zipName := archive.ZipFolderName(library)
 	lib := filepath.Base(filepath.Clean(filepath.Join(repo.FolderPath, "..")))
 	host := filepath.Base(filepath.Clean(filepath.Join(repo.FolderPath, "..", "..")))
-	zipFilePath, err := libraries.ZipRepo(repo.FolderPath, filepath.Join(config.LibrariesFolder, host, lib), zipName)
+	zipFilePath, err := archive.ZipRepo(repo.FolderPath, filepath.Join(config.LibrariesFolder, host, lib), zipName)
 	if err != nil {
 		return fmt.Errorf("Error while zipping library: %s", err)
 	}

--- a/internal/command/sync/sync.go
+++ b/internal/command/sync/sync.go
@@ -40,7 +40,6 @@ import (
 	"github.com/arduino/libraries-repository-engine/internal/libraries/archive"
 	"github.com/arduino/libraries-repository-engine/internal/libraries/db"
 	"github.com/arduino/libraries-repository-engine/internal/libraries/gitutils"
-	"github.com/arduino/libraries-repository-engine/internal/libraries/hash"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/spf13/cobra"
 )
@@ -277,7 +276,7 @@ func syncLibraryTaggedRelease(logger *log.Logger, repo *libraries.Repository, ta
 		return fmt.Errorf("Error while zipping library: %s", err)
 	}
 
-	size, checksum, err := getSizeAndCalculateChecksum(zipFilePath)
+	size, checksum, err := archive.GetSizeAndCalculateChecksum(zipFilePath)
 	if err != nil {
 		return fmt.Errorf("Error while calculating checksums: %s", err)
 	}
@@ -293,22 +292,6 @@ func syncLibraryTaggedRelease(logger *log.Logger, repo *libraries.Repository, ta
 	}
 
 	return nil
-}
-
-func getSizeAndCalculateChecksum(filePath string) (int64, string, error) {
-	info, err := os.Stat(filePath)
-	if err != nil {
-		return -1, "", err
-	}
-
-	size := info.Size()
-
-	checksum, err := hash.Checksum(filePath)
-	if err != nil {
-		return -1, "", err
-	}
-
-	return size, checksum, nil
 }
 
 func outputLogFile(logger *log.Logger, repoMetadata *libraries.Repo, buffer *bytes.Buffer) error {

--- a/internal/libraries/archive/archive.go
+++ b/internal/libraries/archive/archive.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/arduino/libraries-repository-engine/internal/libraries/hash"
 	"github.com/arduino/libraries-repository-engine/internal/libraries/metadata"
 	"github.com/arduino/libraries-repository-engine/internal/libraries/zip"
 )
@@ -52,4 +53,21 @@ func ZipRepo(repoFolder string, baseFolder string, zipFolderName string) (string
 func ZipFolderName(library *metadata.LibraryMetadata) string {
 	pattern := regexp.MustCompile("[^a-zA-Z0-9]")
 	return pattern.ReplaceAllString(library.Name, "_") + "-" + library.Version
+}
+
+// GetSizeAndCalculateChecksum returns the size and SHA-256 checksum for the given file.
+func GetSizeAndCalculateChecksum(filePath string) (int64, string, error) {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return -1, "", err
+	}
+
+	size := info.Size()
+
+	checksum, err := hash.Checksum(filePath)
+	if err != nil {
+		return -1, "", err
+	}
+
+	return size, checksum, nil
 }

--- a/internal/libraries/archive/archive.go
+++ b/internal/libraries/archive/archive.go
@@ -94,10 +94,11 @@ func (archive *Archive) Create() error {
 	return nil
 }
 
+var zipFolderNamePattern = regexp.MustCompile("[^a-zA-Z0-9]")
+
 // zipFolderName returns the name to use for the folder.
 func zipFolderName(library *metadata.LibraryMetadata) string {
-	pattern := regexp.MustCompile("[^a-zA-Z0-9]")
-	return pattern.ReplaceAllString(library.Name, "_") + "-" + library.Version
+	return zipFolderNamePattern.ReplaceAllString(library.Name, "_") + "-" + library.Version
 }
 
 // getSizeAndCalculateChecksum returns the size and SHA-256 checksum for the given file.

--- a/internal/libraries/archive/archive.go
+++ b/internal/libraries/archive/archive.go
@@ -21,7 +21,8 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-package libraries
+// Package archive handles the library release archive.
+package archive
 
 import (
 	"os"

--- a/internal/libraries/archive/archive_test.go
+++ b/internal/libraries/archive/archive_test.go
@@ -1,0 +1,88 @@
+// This file is part of libraries-repository-engine.
+//
+// Copyright 2021 ARDUINO SA (http://www.arduino.cc/)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package archive
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arduino/libraries-repository-engine/internal/configuration"
+	"github.com/arduino/libraries-repository-engine/internal/libraries"
+	"github.com/arduino/libraries-repository-engine/internal/libraries/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testDataPath string
+
+func init() {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	testDataPath = filepath.Join(workingDirectory, "testdata")
+}
+
+func TestNew(t *testing.T) {
+	repository := libraries.Repository{
+		FolderPath: "/qux/repos/some-repo",
+		URL:        "https://github.com/Foo/Bar.git",
+	}
+	libraryMetadata := metadata.LibraryMetadata{
+		Name:    "Foo Bar",
+		Version: "1.2.3",
+	}
+	config := configuration.Config{
+		LibrariesFolder: "/baz/libs/",
+		BaseDownloadURL: "https://example/com/libraries/",
+	}
+
+	archiveObject, err := New(&repository, &libraryMetadata, &config)
+	require.NoError(t, err)
+	assert.Equal(t, "/qux/repos/some-repo", archiveObject.SourcePath)
+	assert.Equal(t, "Foo_Bar-1.2.3", archiveObject.RootName)
+	assert.Equal(t, "Foo_Bar-1.2.3.zip", archiveObject.FileName)
+	assert.Equal(t, filepath.Join("/baz/libs/github.com/Foo/Foo_Bar-1.2.3.zip"), archiveObject.Path)
+	assert.Equal(t, "https://example/com/libraries/github.com/Foo/Foo_Bar-1.2.3.zip", archiveObject.URL)
+}
+
+func TestCreate(t *testing.T) {
+	archiveDir := filepath.Join(os.TempDir(), "TestCreateArchiveDir")
+	defer os.RemoveAll(archiveDir)
+	archivePath := filepath.Join(archiveDir, "TestCreateArchive.zip")
+
+	archiveObject := Archive{
+		Path:       archivePath,
+		SourcePath: filepath.Join(testDataPath, "gitclones", "SomeRepository"),
+		RootName:   "SomeLibrary",
+	}
+
+	err := archiveObject.Create()
+	require.NoError(t, err, "This test must be run as administrator on Windows to have symlink creation privilege.")
+
+	assert.FileExists(t, archivePath)
+	assert.Greater(t, archiveObject.Size, int64(0))
+	assert.NotEmpty(t, archiveObject.Checksum)
+}

--- a/internal/libraries/archive/testdata/gitclones/SomeRepository/SomeFile
+++ b/internal/libraries/archive/testdata/gitclones/SomeRepository/SomeFile
@@ -1,0 +1,2 @@
+This is some arbitrary source content to stand in for a library release. It is not intended to be a Git repository
+because that is not convenient to have in the repository and not relevant to testing this package.

--- a/internal/libraries/git_integration_test.go
+++ b/internal/libraries/git_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/arduino/libraries-repository-engine/internal/libraries/archive"
 	"github.com/arduino/libraries-repository-engine/internal/libraries/db"
 	"github.com/arduino/libraries-repository-engine/internal/libraries/gitutils"
 	"github.com/stretchr/testify/require"
@@ -68,11 +69,11 @@ func TestUpdateLibraryJson(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, library)
 
-		zipFolderName := ZipFolderName(library)
+		zipFolderName := archive.ZipFolderName(library)
 
 		release := db.FromLibraryToRelease(library)
 
-		zipFilePath, err := ZipRepo(r.FolderPath, librariesRepo, zipFolderName)
+		zipFilePath, err := archive.ZipRepo(r.FolderPath, librariesRepo, zipFolderName)
 		require.NoError(t, err)
 		require.NotEmpty(t, zipFilePath)
 

--- a/internal/libraries/git_integration_test.go
+++ b/internal/libraries/git_integration_test.go
@@ -21,7 +21,7 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-package libraries
+package libraries_test
 
 import (
 	"io/ioutil"
@@ -29,6 +29,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/arduino/libraries-repository-engine/internal/configuration"
+	"github.com/arduino/libraries-repository-engine/internal/libraries"
 	"github.com/arduino/libraries-repository-engine/internal/libraries/archive"
 	"github.com/arduino/libraries-repository-engine/internal/libraries/db"
 	"github.com/arduino/libraries-repository-engine/internal/libraries/gitutils"
@@ -36,7 +38,7 @@ import (
 )
 
 func TestUpdateLibraryJson(t *testing.T) {
-	repos, err := ListRepos("./testdata/git_test_repo.txt")
+	repos, err := libraries.ListRepos("./testdata/git_test_repo.txt")
 
 	require.NoError(t, err)
 	require.NotNil(t, repos)
@@ -52,7 +54,7 @@ func TestUpdateLibraryJson(t *testing.T) {
 		subfolder, err := repo.AsFolder()
 		require.NoError(t, err)
 
-		r, err := CloneOrFetch(repo, filepath.Join("/tmp", subfolder))
+		r, err := libraries.CloneOrFetch(repo, filepath.Join("/tmp", subfolder))
 		require.NoError(t, err)
 		require.NotNil(t, r)
 
@@ -65,19 +67,21 @@ func TestUpdateLibraryJson(t *testing.T) {
 
 		err = gitutils.CheckoutTag(r.Repository, tag)
 
-		library, err := GenerateLibraryFromRepo(r)
+		library, err := libraries.GenerateLibraryFromRepo(r)
 		require.NoError(t, err)
 		require.NotNil(t, library)
 
-		zipFolderName := archive.ZipFolderName(library)
+		config := configuration.Config{LibrariesFolder: librariesRepo}
+		archiveData, err := archive.New(r, library, &config)
+		require.NoError(t, err)
 
 		release := db.FromLibraryToRelease(library)
 
-		zipFilePath, err := archive.ZipRepo(r.FolderPath, librariesRepo, zipFolderName)
+		err = archiveData.Create()
 		require.NoError(t, err)
-		require.NotEmpty(t, zipFilePath)
+		require.NotEmpty(t, archiveData.Path)
 
-		err = UpdateLibrary(release, r.URL, libraryDb)
+		err = libraries.UpdateLibrary(release, r.URL, libraryDb)
 		require.NoError(t, err)
 
 	}


### PR DESCRIPTION
The planned addition of Library Manager content maintenance capabilities to the tool requires that all data related to the library release archives be accessible via the internal API.

I found that the Git clone path naming had been used unnecessarily as the basis for the archive paths naming, even though the end goal was to base it on the library repository name. They are based on this URL to different extents, so this really made no sense.