### PR TITLE
Add types modification capability to modify command

### DIFF
--- a/internal/cli/modify.go
+++ b/internal/cli/modify.go
@@ -42,6 +42,7 @@ Modify the registration data of library name LIBRARY_NAME according to the FLAGs
 
 func init() {
 	modifyCmd.Flags().String("repo-url", "", "New library repository URL")
+	modifyCmd.Flags().String("types", "", "New types list for the library's releases (comma separated)")
 
 	rootCmd.AddCommand(modifyCmd)
 }

--- a/test/testdata/test_modify/test_types/repos.txt
+++ b/test/testdata/test_modify/test_types/repos.txt
@@ -1,0 +1,2 @@
+https://github.com/arduino-libraries/SpacebrewYun.git|Arduino|SpacebrewYun
+https://github.com/arduino-libraries/UnoWiFi-Developer-Edition-Lib.git|Partner|Arduino Uno WiFi Dev Ed Library


### PR DESCRIPTION
Although much of the Library Manager content is based on the contents of the individual library repositories, some is
defined during the library registration, and so a change to this after the time of the registration requires direct
action by a maintainer. A `--types` flag is now added to the command to allow the library types list (e.g., "Arduino",
"Contributed", "Retired") to be modified in the releases database for the given library.

```
libraries-repository-engine modify --types=NEW_TYPES LIBRARY_NAME
```

will change the types list of all releases of the library name specified via the positional argument (LIBRARY_NAME) to the
new list specified via the `--types` flag's comma separated list (NEW_FLAGS).