### PR TITLE
Remove unused `SupportLevel` database field

### DIFF
--- a/internal/libraries/db/db.go
+++ b/internal/libraries/db/db.go
@@ -43,9 +43,8 @@ type DB struct {
 
 // Library is an Arduino library
 type Library struct {
-	Name         string
-	Repository   string
-	SupportLevel string
+	Name       string
+	Repository string
 
 	// Category of the latest release of the library
 	LatestCategory string

--- a/internal/libraries/db/db_test.go
+++ b/internal/libraries/db/db_test.go
@@ -34,19 +34,16 @@ func testerDB() *DB {
 	tDB := DB{
 		Libraries: []*Library{
 			{
-				Name:         "FooLib",
-				Repository:   "https://github.com/Bar/FooLib.git",
-				SupportLevel: "",
+				Name:       "FooLib",
+				Repository: "https://github.com/Bar/FooLib.git",
 			},
 			{
-				Name:         "BazLib",
-				Repository:   "https://github.com/Bar/BazLib.git",
-				SupportLevel: "",
+				Name:       "BazLib",
+				Repository: "https://github.com/Bar/BazLib.git",
 			},
 			{
-				Name:         "QuxLib",
-				Repository:   "https://github.com/Zeb/QuxLib.git",
-				SupportLevel: "",
+				Name:       "QuxLib",
+				Repository: "https://github.com/Zeb/QuxLib.git",
 			},
 		},
 		Releases: []*Release{

--- a/internal/libraries/db/index.go
+++ b/internal/libraries/db/index.go
@@ -48,8 +48,6 @@ type indexLibrary struct {
 	ArchiveFileName  string             `json:"archiveFileName"`
 	Size             int64              `json:"size"`
 	Checksum         string             `json:"checksum"`
-
-	SupportLevel string `json:"supportLevel,omitempty"`
 }
 
 type indexDependency struct {
@@ -96,7 +94,6 @@ func (db *DB) OutputLibraryIndex() (interface{}, error) {
 				URL:              libraryRelease.URL,
 				Size:             libraryRelease.Size,
 				Checksum:         libraryRelease.Checksum,
-				SupportLevel:     lib.SupportLevel,
 				Repository:       lib.Repository,
 				ProvidesIncludes: libraryRelease.Includes,
 				Dependencies:     deps,

--- a/tests/testdata/test_sync/golden/db.json
+++ b/tests/testdata/test_sync/golden/db.json
@@ -3,13 +3,11 @@
     {
       "Name": "SpacebrewYun",
       "Repository": "https://github.com/arduino-libraries/SpacebrewYun.git",
-      "SupportLevel": "",
       "LatestCategory": "Communication"
     },
     {
       "Name": "ArduinoCloudThing",
       "Repository": "https://github.com/arduino-libraries/ArduinoCloudThing.git",
-      "SupportLevel": "",
       "LatestCategory": "Communication"
     }
   ],


### PR DESCRIPTION
`db.Library.SupportLevel` was not filled for any library in the database and there is no use of this field's value by any
Arduino software. Since the index field has the `omitempty` tag, it was never marshalled when generating the
`library_index.json` filethat is the consumed output from the database.

Although it's not clear what the intended purpose was for this field, the `Types` field of the database's releases does
provide some indication of a support level. For example the "Arduino" type is used for official libraries, meaning they
are directly supported by Arduino. The "Retired" type would indicate it is no longer supported. The "Contributed" type is
used for 3rd party libraries submitted to the Library Manager index, indicating that direct support is the responsibility
of the 3rd party library maintainer.

Since the field is not used and there are no current plans for its use nor even recollection of what the plan was at the
time it was added, it only adds unnecessary complexity to the code. It is best to remove it. There will be no impact on
the public API. We can always add an equivalent field back if we later determine that it would be useful to record more
information about a library's support level than is already contained in the `Type` field.