### PR TITLE
Use previous tag as base when "Compare Performance" workflow triggered by tag

### DIFF
--- a/.github/workflows/compare-performance.yml
+++ b/.github/workflows/compare-performance.yml
@@ -43,11 +43,11 @@ jobs:
         id: base-ref
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "::set-output name=ref::${{ github.event.inputs.comparison-ref }}"
+            COMPARISON_REF="${{ github.event.inputs.comparison-ref }}"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "::set-output name=ref::${{ github.base_ref }}"
+            COMPARISON_REF="${{ github.base_ref }}"
           elif [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
-            PREV_TAG="$( \
+            COMPARISON_REF="$( \
               git ls-remote \
               --quiet \
               --tags \
@@ -59,10 +59,16 @@ jobs:
                     tail -2 | \
                       head -1
             )"
-            echo "::set-output name=ref::$PREV_TAG"
           else
-            echo "::set-output name=ref::${{ github.event.before }}"
+            COMPARISON_REF="${{ github.event.before }}"
           fi
+
+          if [[ "$COMPARISON_REF" == "" ]]; then
+            echo "::error::Unable to determine comparison ref"
+            exit 1
+          fi
+
+          echo "::set-output name=ref::$COMPARISON_REF"
 
   run:
     name: Run at ${{ matrix.data.ref }} (${{ matrix.data.description }})

--- a/.github/workflows/compare-performance.yml
+++ b/.github/workflows/compare-performance.yml
@@ -34,6 +34,11 @@ jobs:
       base-ref: ${{ steps.base-ref.outputs.ref }}
 
     steps:
+      # Repo is required to get the previous tag ref that is the base of the comparison on tag push triggered run.
+      - name: Checkout repository
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/checkout@v2
+
       - name: Determine comparison ref
         id: base-ref
         run: |
@@ -41,6 +46,20 @@ jobs:
             echo "::set-output name=ref::${{ github.event.inputs.comparison-ref }}"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "::set-output name=ref::${{ github.base_ref }}"
+          elif [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
+            PREV_TAG="$( \
+              git ls-remote \
+              --quiet \
+              --tags \
+              --refs \
+              --sort=version:refname | \
+                cut \
+                  --delimiter='/' \
+                  --fields=3 | \
+                    tail -2 | \
+                      head -1
+            )"
+            echo "::set-output name=ref::$PREV_TAG"
           else
             echo "::set-output name=ref::${{ github.event.before }}"
           fi


### PR DESCRIPTION
The engine has three trigger events, each with their own base ref:

- push: parent commit
- pull request: PR base ref
- manual trigger: arbitrary ref selected by the user

The `push` event is triggered by both commit pushes and tag pushes. It turns out the github context field that provides
the parent commit ref is set to `0000000000000000000000000000000000000000` on a tag push, which caused the workflow to
fail. Although it would be possible to get the parent commit ref via a git command, this isn't a useful comparison to get
from a tag push. The more useful comparison will be against the previous tag.

---
Previous version of the workflow failing on a tag push:
https://github.com/arduino/libraries-repository-engine/actions/runs/1194197512
Demo of this version triggered by a tag push:
https://github.com/per1234/libraries-repository-engine/actions/runs/1198521674