### PR TITLE
Get reliable base ref for push-triggered "Compare Performance" workflow

### DIFF
--- a/.github/workflows/compare-performance.yml
+++ b/.github/workflows/compare-performance.yml
@@ -36,8 +36,11 @@ jobs:
     steps:
       # Repo is required to get the previous tag ref that is the base of the comparison on tag push triggered run.
       - name: Checkout repository
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        if: github.event_name == 'push'
         uses: actions/checkout@v2
+        with:
+          # Parent commit is needed for determining the base ref on commit push trigg.
+          fetch-depth: 2
 
       - name: Determine comparison ref
         id: base-ref
@@ -60,7 +63,7 @@ jobs:
                       head -1
             )"
           else
-            COMPARISON_REF="${{ github.event.before }}"
+            COMPARISON_REF="$(git rev-parse ${{ github.sha }}^)"
           fi
 
           if [[ "$COMPARISON_REF" == "" ]]; then


### PR DESCRIPTION
The "Compare Performance" GitHub Actions workflow is intended to assist in the evaluation of performance impact of
proposed changes to the tool. It does this by comparing the duration of a run of the engine at the head ref of the
proposal against a base ref.

In the case where the workflow is triggered by a `push` event from a commit, the base ref should be the parent commit.
The previous approach of using the `github.event.before` [context item](https://docs.github.com/en/actions/learn-github-actions/contexts) was unreliable because this is set to the fake ref
`0000000000000000000000000000000000000000` when there has not been a previous workflow run on the branch (as is the case
when branch and commit are pushed from a local to the remote). Example:

https://github.com/arduino/libraries-repository-engine/runs/4538811651?check_suite_focus=true