### PR TITLE
Don't preserve old repository on URL change

### DIFF
--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -227,9 +227,6 @@ def test_repo_url(
     new_library_release_archives_folder = pathlib.Path(configuration.data["LibrariesFolder"]).joinpath(
         new_host, new_owner
     )
-    new_git_clone_path = pathlib.Path(configuration.data["GitClonesFolder"]).joinpath(
-        new_host, new_owner, new_repo_name
-    )
     # The "canary" library is not modified and so all its content should remain unchanged after running the command
     canary_name = "ArduinoIoTCloudBearSSL"
     sanitized_canary_name = "ArduinoIoTCloudBearSSL"
@@ -281,7 +278,6 @@ def test_repo_url(
         raise
 
     assert old_git_clone_path.exists()
-    assert not new_git_clone_path.exists()
     assert canary_git_clone_path.exists()
     assert get_library_repo_url(name=name) != new_repo_url
     assert get_library_repo_url(name=canary_name) == canary_repo_url
@@ -314,7 +310,6 @@ def test_repo_url(
 
     # Verify the effect of the command was as expected
     assert not old_git_clone_path.exists()
-    assert new_git_clone_path.exists()
     assert canary_release_archive_path.exists()
     assert canary_git_clone_path.exists()
     assert get_library_repo_url(name=name) == new_repo_url


### PR DESCRIPTION
The library maintainers may [request a change to the repository URL in the library registration data](https://github.com/arduino/library-registry#changing-the-url-of-a-library-already-in-library-manager).

This operation is performed by the backend maintainer via the command:

```text
libraries-repository-engine modify --repo-url
```

Previously, this command did three things:

- Update the DB entry for the library
- Move the release archives to the new location (the storage structure is based on the repository URL for some reason)
- Move the cached library repository clone to the new location

## Problem

The last of these is problematic because the remote of that repository is still configured for the original URL, meaning
the fetch done during the `sync` command execution were still done against the old URL.

This bug is not noticeable under either of the following scenarios:

---

### The repository was renamed or transferred

This produces a redirect from the old URL to the new one, so the fetch is done from the intended repo despite the
outdated remote configuration.

---

### The original repository was deleted

If a fetch fails, the engine deletes the repository and clones from the URL in the DB. The newly cloned repo will have
the correct remote configuration.

----

The bug is noticeable under the following scenario:

---

### The original repository still exists

The sync process continues to fetch from the old URL.

Example: https://github.com/arduino/library-registry/pull/1179#issuecomment-1069580633

---

## Solution

Change the `modify --repo-url` command behavior to delete the cached library repository clone.

The repository will be cloned from the updated URL on the next run of the `sync` command.