### PR TITLE
Adjust release workflow for new "v"-prefixed tag format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ env:
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   release:
@@ -58,7 +58,7 @@ jobs:
       - name: Create changelog
         uses: arduino/create-changelog@v1
         with:
-          tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
+          tag-regex: '^v?[0-9]+\.[0-9]+\.[0-9]+.*$'
           filter-regex: '^\[(skip|changelog)[ ,-](skip|changelog)\].*'
           case-insensitive-regex: true
           changelog-file-path: ${{ env.CHANGELOG_PATH }}


### PR DESCRIPTION
The Go modules system requires the release Git tags to [start with a "v" prefix](https://go.dev/ref/mod#versions). Historically, this project has used the otherwise more sensible approach of using the exact version number as a tag name.

This meant that the module could only be used as a dependency via ["pseudo-versions"](https://go.dev/ref/mod#pseudo-versions).

For example, `go get github.com/arduino/libraries-repository-engine@latest` currently adds this travesty to your
`go.mod` file:

```text
require github.com/arduino/libraries-repository-engine v0.0.0-20220321045648-4999750bf965
```

This causes several problems:

- Unstable non-release versions of the module are more likely to be used by dependent projects
- Automated release update services (i.e., Dependabot) are not available, resulting in dependent projects using outdated   versions of the module

The release workflow was configured for the previous non-prefixed tag format, so it must be adjusted for the new "v" prefixed tag format.