### PR TITLE
Use form-based issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,0 @@
----
-name: Bug report
-about: Report problems with the code in this repository.
-title: ""
-labels: "type: imperfection"
-assignees: ""
----

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,45 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/forms/general/bug-report.yml
+# See: https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+
+name: Bug report
+description: Report a problem with the code or documentation in this repository.
+labels:
+  - "type: imperfection"
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: To reproduce
+      description: Provide the specific set of steps we can follow to reproduce the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What would you expect to happen after following those instructions?
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any additional information here.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Issue checklist
+      description: Please double-check that you have done each of the following things before submitting the issue.
+      options:
+        - label: I searched for previous reports in [the issue tracker](https://github.com/arduino/libraries-repository-engine/issues?q=)
+          required: true
+        - label: My report contains all necessary details
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,17 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/template-choosers/general/config.yml
+# See: https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+
+blank_issues_enabled: true
 contact_links:
+  - name: Learn about using this project
+    url: https://github.com/arduino/libraries-repository-engine#readme
+    about: Detailed usage documentation is available here.
   - name: Learn about the Arduino Library Manager indexer
     url: https://github.com/arduino/library-registry/blob/main/FAQ.md#arduino-library-manager-faq
     about: Frequently asked questions about the Library Manager indexer.
   - name: Support request
     url: https://forum.arduino.cc/
     about: We can help you out on the Arduino Forum!
+  - name: Discuss development work on the project
+    url: https://groups.google.com/a/arduino.cc/g/developers
+    about: Arduino Developers Mailing List

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,0 @@
----
-name: Feature request
-about: Suggest an improvement for this project.
-title: ""
-labels: "type: enhancement"
-assignees: ""
----

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,40 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/forms/general/bug-report.yml
+# See: https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+
+name: Feature request
+description: Suggest an enhancement to this project.
+labels:
+  - "type: enhancement"
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the request
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Describe the current behavior
+      description: |
+        What is the current behavior of libraries-repository-engine in relation to your request?
+        How can we reproduce that behavior?
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any additional information here.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Issue checklist
+      description: Please double-check that you have done each of the following things before submitting the issue.
+      options:
+        - label: I searched for previous requests in [the issue tracker](https://github.com/arduino/libraries-repository-engine/issues?q=)
+          required: true
+        - label: My request contains all necessary details
+          required: true


### PR DESCRIPTION
High quality feedback via GitHub issues is a very valuable contribution to the project. It is important to make the issue creation and management process as efficient as possible for the contributors, maintainers, and developers.

Issue templates are helpful to the maintainers and developers because it establishes a standardized framework for the issues and encourages the contributors to provide the essential information.

The contributor is now presented with [a web form](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) when creating an issue. This consists of multi-line input fields that have the same formatting, preview, and attachment capabilities as the standard GitHub Issue composer, in addition to menus and checkboxes where appropriate.

The use of this form-based system should provide a better issue creation experience and result in higher quality issues by establishing a standardized framework for the issues and encouraging contributors to provide the essential information.

A [template chooser](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) allows the contributor to select the appropriate template type, redirects support requests to the appropriate communication channels via "Contact Links", and provides a prominent link to the security policy in order to guide any vulnerability disclosures.

The clear separation of the types of issues encourages the reporter to fit their report into a specific issue category, resulting in more clarity. Automatic labeling according to template choice allows the reporter to do the initial classification.

---

A preview of how the system will work can be seen here:

https://github.com/per1234/libraries-repository-engine/issues/new/choose

Due to that demo being from the staged version in my fork, the `arduino` GitHub organization's security policy link is absent from the chooser, but it will automatically appear in the chooser of this repo.
