### PR TITLE
Remove redundant and outdated validation from `depends` extraction regex

### DIFF
--- a/internal/libraries/db/dependencies_test.go
+++ b/internal/libraries/db/dependencies_test.go
@@ -45,8 +45,6 @@ func TestDependencyExtract(t *testing.T) {
 		require.Nil(t, dep)
 		require.Error(t, err)
 	}
-	invalid("-invalidname")
-	invalid("_invalidname")
 	check("ciao", []string{"ciao"}, []string{""})
 	check("MyLib (>1.2.3)", []string{"MyLib"}, []string{">1.2.3"})
 	check("MyLib (>=1.2.3)", []string{"MyLib"}, []string{">=1.2.3"})
@@ -60,8 +58,8 @@ func TestDependencyExtract(t *testing.T) {
 	check("MyLib (>=1.2.3),AnotherLib, YetAnotherLib (=1.0.0)",
 		[]string{"MyLib", "AnotherLib", "YetAnotherLib"},
 		[]string{">=1.2.3", "", "=1.0.0"})
-	invalid("MyLib (>=1.2.3),_aaaa")
 	invalid("MyLib,,AnotherLib")
+	invalid("(MyLib)")
 	invalid("MyLib(=1.2.3)")
 	check("Arduino Uno WiFi Dev Ed Library, LoRa Node (^2.1.2)",
 		[]string{"Arduino Uno WiFi Dev Ed Library", "LoRa Node"},

--- a/internal/libraries/db/dependencies_test.go
+++ b/internal/libraries/db/dependencies_test.go
@@ -48,14 +48,21 @@ func TestDependencyExtract(t *testing.T) {
 	invalid("-invalidname")
 	invalid("_invalidname")
 	check("ciao", []string{"ciao"}, []string{""})
+	check("MyLib (>1.2.3)", []string{"MyLib"}, []string{">1.2.3"})
 	check("MyLib (>=1.2.3)", []string{"MyLib"}, []string{">=1.2.3"})
+	check("MyLib (<1.2.3)", []string{"MyLib"}, []string{"<1.2.3"})
+	check("MyLib (<=1.2.3)", []string{"MyLib"}, []string{"<=1.2.3"})
+	check("MyLib (!=1.2.3)", []string{"MyLib"}, []string{"!=1.2.3"})
+	check("MyLib (>1.0.0 && <2.1.0)", []string{"MyLib"}, []string{">1.0.0 && <2.1.0"})
+	check("MyLib (<1.0.0 || >2.0.0)", []string{"MyLib"}, []string{"<1.0.0 || >2.0.0"})
+	check("MyLib ((>0.1.0 && <2.0.0) || >2.1.0)", []string{"MyLib"}, []string{"(>0.1.0 && <2.0.0) || >2.1.0"})
+	check("MyLib ()", []string{"MyLib"}, []string{""})
 	check("MyLib (>=1.2.3),AnotherLib, YetAnotherLib (=1.0.0)",
 		[]string{"MyLib", "AnotherLib", "YetAnotherLib"},
 		[]string{">=1.2.3", "", "=1.0.0"})
-	invalid("MyLib (>=1.2.3)()")
 	invalid("MyLib (>=1.2.3),_aaaa")
 	invalid("MyLib,,AnotherLib")
-	invalid("MyLib (>=1.2.3)(),AnotherLib, YetAnotherLib (=1.0.0)")
+	invalid("MyLib(=1.2.3)")
 	check("Arduino Uno WiFi Dev Ed Library, LoRa Node (^2.1.2)",
 		[]string{"Arduino Uno WiFi Dev Ed Library", "LoRa Node"},
 		[]string{"", "^2.1.2"})

--- a/internal/libraries/db/library.go
+++ b/internal/libraries/db/library.go
@@ -66,7 +66,7 @@ func extractStringList(value string) []string {
 	return res
 }
 
-var re = regexp.MustCompile("^([a-zA-Z0-9](?:[a-zA-Z0-9._\\- ]*[a-zA-Z0-9])?) *(?: \\((.*)\\))?$")
+var re = regexp.MustCompile("^([^()]+?) *(?: \\((.*)\\))?$")
 
 // ExtractDependenciesList extracts dependencies from the "depends" field of library.properties
 func ExtractDependenciesList(depends string) ([]*Dependency, error) {

--- a/internal/libraries/db/library.go
+++ b/internal/libraries/db/library.go
@@ -66,7 +66,7 @@ func extractStringList(value string) []string {
 	return res
 }
 
-var re = regexp.MustCompile("^([a-zA-Z0-9](?:[a-zA-Z0-9._\\- ]*[a-zA-Z0-9])?) *(?: \\(([^()]*)\\))?$")
+var re = regexp.MustCompile("^([a-zA-Z0-9](?:[a-zA-Z0-9._\\- ]*[a-zA-Z0-9])?) *(?: \\((.*)\\))?$")
 
 // ExtractDependenciesList extracts dependencies from the "depends" field of library.properties
 func ExtractDependenciesList(depends string) ([]*Dependency, error) {


### PR DESCRIPTION
Library dependencies may be specified in the `depends` field of [the `library.properties` library metadata file](https://arduino.github.io/arduino-cli/dev/library-specification/#library-metadata).

A regular expression is used to separate the library dependency name and optional version constraint from each element of the field during parsing of the file to add new releases to the DB.

This regular expression is also configured to validate the library name as well as some minimal attempt at validating the version constraint.

The latter is not compatible with the [recently introduced]((https://github.com/bugst/relaxed-semver/commit/731277054e56fd8ccfeeebd3491edb8ffef1f844)) more powerful [constraint syntax](https://github.com/bugst/relaxed-semver#version-constraints).

This project was originally solely responsible for validation of the library releases. Since that time, a dedicated tool was created for this purpose: [Arduino Lint](https://arduino.github.io/arduino-lint/latest/).

Since Arduino Lint already fully validates each release, including the `depends` field contents, and the DB entries are only added for releases [which have passed that check](https://github.com/arduino/libraries-repository-engine/blob/1386c82e33d436f25bf53ff79d57c96d7e8ae2af/internal/command/sync/sync.go#L248), the validation via the extraction regular expression is superfluous and only increases the maintenance burden for no benefit.

The regular expression is now configured for its a single purpose: extracting the components of the `depends` field elements. This can be done via a more simple regular expression, given that the data being parsed has already been validated by Arduino Lint.