### PR TITLE
Don't error maintenance commands on missing library clone folder

### DIFF
--- a/internal/command/modify/modify.go
+++ b/internal/command/modify/modify.go
@@ -164,17 +164,8 @@ func modifyRepositoryURL(newRepositoryURL string) error {
 	fmt.Printf("Changing URL of library %s from %s to %s\n", libraryName, oldRepositoryURL, newRepositoryURL)
 
 	// Remove the library Git clone folder. It will be cloned from the new URL on the next sync.
-	libraryRegistration := libraries.Repo{URL: libraryData.Repository}
-	gitCloneSubfolder, err := libraryRegistration.AsFolder()
-	if err != nil {
+	if err := libraries.BackupAndDeleteGitClone(config, &libraries.Repo{URL: libraryData.Repository}); err != nil {
 		return err
-	}
-	gitClonePath := paths.New(config.GitClonesFolder, gitCloneSubfolder)
-	if err := backup.Backup(gitClonePath); err != nil {
-		return fmt.Errorf("While backing up library's Git clone: %w", err)
-	}
-	if err := gitClonePath.RemoveAll(); err != nil {
-		return fmt.Errorf("While removing library's Git clone: %w", err)
 	}
 
 	// Update the library repository URL in the database.

--- a/internal/command/remove/remove.go
+++ b/internal/command/remove/remove.go
@@ -160,17 +160,8 @@ func removeLibrary(libraryName string) error {
 	}
 
 	// Remove the library Git clone folder.
-	libraryRegistration := libraries.Repo{URL: libraryData.Repository}
-	gitCloneSubfolder, err := libraryRegistration.AsFolder()
-	if err != nil {
+	if err := libraries.BackupAndDeleteGitClone(config, &libraries.Repo{URL: libraryData.Repository}); err != nil {
 		return err
-	}
-	gitClonePath := paths.New(config.GitClonesFolder, gitCloneSubfolder)
-	if err := backup.Backup(gitClonePath); err != nil {
-		return fmt.Errorf("While backing up library's Git clone: %w", err)
-	}
-	if err := gitClonePath.RemoveAll(); err != nil {
-		return fmt.Errorf("While removing library Git clone: %s", err)
 	}
 
 	return nil

--- a/internal/libraries/repoclone.go
+++ b/internal/libraries/repoclone.go
@@ -28,6 +28,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/arduino/go-paths-helper"
+	"github.com/arduino/libraries-repository-engine/internal/backup"
+	"github.com/arduino/libraries-repository-engine/internal/configuration"
 	"github.com/arduino/libraries-repository-engine/internal/libraries/db"
 
 	"fmt"
@@ -130,6 +133,24 @@ func UpdateLibrary(release *db.Release, repoURL string, libraryDb *db.DB) error 
 	err = libraryDb.Commit()
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// BackupAndDeleteGitClone backs up and then deletes the library's Git clone folder.
+func BackupAndDeleteGitClone(config *configuration.Config, repoMeta *Repo) error {
+	gitCloneSubfolder, err := repoMeta.AsFolder()
+	if err != nil {
+		return err
+	}
+	gitClonePath := paths.New(config.GitClonesFolder, gitCloneSubfolder)
+
+	if err := backup.Backup(gitClonePath); err != nil {
+		return fmt.Errorf("While backing up library's Git clone: %w", err)
+	}
+	if err := gitClonePath.RemoveAll(); err != nil {
+		return fmt.Errorf("While removing library Git clone: %s", err)
 	}
 
 	return nil

--- a/internal/libraries/repoclone_test.go
+++ b/internal/libraries/repoclone_test.go
@@ -65,7 +65,7 @@ func TestBackupAndDeleteGitClone(t *testing.T) {
 		URL: "https://github.com/Foo/Bar.git",
 	}
 
-	assert.Error(t, BackupAndDeleteGitClone(&config, &repoMeta), "Error if library clone folder did not exist.")
+	assert.Nil(t, BackupAndDeleteGitClone(&config, &repoMeta), "Return nil if library clone folder did not exist.")
 
 	gitCloneSubfolder, err := repoMeta.AsFolder()
 	require.NoError(t, err)

--- a/internal/libraries/repoclone_test.go
+++ b/internal/libraries/repoclone_test.go
@@ -28,6 +28,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/arduino/go-paths-helper"
+	"github.com/arduino/libraries-repository-engine/internal/backup"
+	"github.com/arduino/libraries-repository-engine/internal/configuration"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,4 +51,39 @@ func TestCloneRepos(t *testing.T) {
 
 	_, err = os.Stat(repo.FolderPath)
 	require.NoError(t, err)
+}
+
+func TestBackupAndDeleteGitClone(t *testing.T) {
+	var err error
+
+	gitClonesFolder, err := paths.MkTempDir("", "libraries-test-testbackupanddeletegitclone")
+	require.NoError(t, err)
+	config := configuration.Config{
+		GitClonesFolder: gitClonesFolder.String(),
+	}
+	repoMeta := Repo{
+		URL: "https://github.com/Foo/Bar.git",
+	}
+
+	assert.Error(t, BackupAndDeleteGitClone(&config, &repoMeta), "Error if library clone folder did not exist.")
+
+	gitCloneSubfolder, err := repoMeta.AsFolder()
+	require.NoError(t, err)
+	gitClonePath := paths.New(config.GitClonesFolder, gitCloneSubfolder)
+	err = gitClonePath.MkdirAll()
+	require.NoError(t, err)
+
+	assert.Nil(t, BackupAndDeleteGitClone(&config, &repoMeta), "Return nil if library clone folder did exist.")
+
+	exist, err := gitClonePath.ExistCheck()
+	require.NoError(t, err)
+
+	assert.False(t, exist, "Library clone folder was deleted.")
+
+	err = backup.Restore()
+	require.NoError(t, err)
+	exist, err = gitClonePath.ExistCheck()
+	require.NoError(t, err)
+
+	assert.True(t, exist, "Library clone folder was backed up.")
 }


### PR DESCRIPTION
The maintenance commands `libraries-repository-engine modify` and `libraries-repository-engine remove` are designed in a conservative manner where the operation is to be immediately halted and all affected data restored if any unexpected conditions are encountered.

Previously, the absence of a library's "Git clone folder" targeted for deletion was considered such an unexpected condition.

Investigation of some failures during the course of maintenance operations revealed that this folder may be absent under certain expected conditions.

The reason is that the "sync" operation deletes the folder after a failed `git fetch` operation before trying a `git clone` of a fresh copy of the repository. If that retry fails, the result is that there is no longer a "Git clone folder" for that library on Arduino's server.

https://github.com/arduino/libraries-repository-engine/blob/4fd9cf76905e83d486b2e3124a8919bd971c4aae/internal/command/sync/sync.go#L167-L179

So the absence of this folder should not be treated as cause for the maintenance command to fail. Instead, the command should warn the user (i.e., the library registry backend maintainer) of the situation and then carry on with the operation.