### PR TITLE
Fix arduino-lint-report temp dir cleanup

### DIFF
--- a/internal/libraries/lint.go
+++ b/internal/libraries/lint.go
@@ -58,8 +58,8 @@ func RunArduinoLint(arduinoLintPath string, folder string, metadata *Repo) ([]by
 	if err != nil {
 		panic(err)
 	}
+	defer os.RemoveAll(JSONReportFolder)
 	JSONReportPath := filepath.Join(JSONReportFolder, "report.json")
-	defer os.RemoveAll(JSONReportPath)
 
 	// See: https://arduino.github.io/arduino-lint/latest/commands/arduino-lint/
 	cmd := exec.Command(

--- a/internal/libraries/lint.go
+++ b/internal/libraries/lint.go
@@ -26,7 +26,6 @@ package libraries
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -55,7 +54,7 @@ func RunArduinoLint(arduinoLintPath string, folder string, metadata *Repo) ([]by
 		arduinoLintPath = "arduino-lint"
 	}
 
-	JSONReportFolder, err := ioutil.TempDir("", "arduino-lint-report-")
+	JSONReportFolder, err := os.MkdirTemp("", "arduino-lint-report-")
 	if err != nil {
 		panic(err)
 	}
@@ -82,7 +81,7 @@ func RunArduinoLint(arduinoLintPath string, folder string, metadata *Repo) ([]by
 	}
 
 	// Read report.
-	rawJSONReport, err := ioutil.ReadFile(JSONReportPath)
+	rawJSONReport, err := os.ReadFile(JSONReportPath)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Previously a stray `/tmp/arduino-lint-report-xxxxx` was leftover.