### PR TITLE
Disable CGO in builds to avoid linking newest GLIBC

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,7 +67,7 @@ tasks:
     desc: Build the Go code
     dir: "{{.DEFAULT_GO_MODULE_PATH}}"
     cmds:
-      - go build -v -o libraries-repository-engine{{exeExt}} {{.LDFLAGS}}
+      - CGO_ENABLED=0 go build -v -o libraries-repository-engine{{exeExt}} {{.LDFLAGS}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-go-task/Taskfile.yml
   go:test:


### PR DESCRIPTION
We can avoid linking newest GLIBC that are not available on the runner:

```
$ ./libraries-repository-engine
./libraries-repository-engine: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./libraries-repository-engine)
./libraries-repository-engine: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./libraries-repository-engine)
```