### PR TITLE
Update format of dependency license metadata

### DIFF
--- a/.licenses/libraries-repository-engine/go/github.com/ProtonMail/go-crypto/bitcurves.dep.yml
+++ b/.licenses/libraries-repository-engine/go/github.com/ProtonMail/go-crypto/bitcurves.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/ProtonMail/go-crypto/bitcurves
 version: v1.1.5
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/ProtonMail/go-crypto/bitcurves
 license: bsd-3-clause
 licenses:

--- a/.licenses/libraries-repository-engine/go/github.com/ProtonMail/go-crypto/internal/byteutil.dep.yml
+++ b/.licenses/libraries-repository-engine/go/github.com/ProtonMail/go-crypto/internal/byteutil.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/ProtonMail/go-crypto/internal/byteutil
 version: v1.1.5
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/ProtonMail/go-crypto/internal/byteutil
 license: bsd-3-clause
 licenses:

--- a/.licenses/libraries-repository-engine/go/github.com/ProtonMail/go-crypto/openpgp/internal/algorithm.dep.yml
+++ b/.licenses/libraries-repository-engine/go/github.com/ProtonMail/go-crypto/openpgp/internal/algorithm.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/ProtonMail/go-crypto/openpgp/internal/algorithm
 version: v1.1.5
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/ProtonMail/go-crypto/openpgp/internal/algorithm
 license: bsd-3-clause
 licenses:

--- a/.licenses/libraries-repository-engine/go/github.com/ProtonMail/go-crypto/openpgp/x25519.dep.yml
+++ b/.licenses/libraries-repository-engine/go/github.com/ProtonMail/go-crypto/openpgp/x25519.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/ProtonMail/go-crypto/openpgp/x25519
 version: v1.1.5
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/ProtonMail/go-crypto/openpgp/x25519
 license: bsd-3-clause
 licenses:

--- a/.licenses/libraries-repository-engine/go/github.com/ProtonMail/go-crypto/openpgp/x448.dep.yml
+++ b/.licenses/libraries-repository-engine/go/github.com/ProtonMail/go-crypto/openpgp/x448.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/ProtonMail/go-crypto/openpgp/x448
 version: v1.1.5
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/ProtonMail/go-crypto/openpgp/x448
 license: bsd-3-clause
 licenses:

--- a/.licenses/libraries-repository-engine/go/github.com/arduino/go-paths-helper.dep.yml
+++ b/.licenses/libraries-repository-engine/go/github.com/arduino/go-paths-helper.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/arduino/go-paths-helper
 version: v1.12.1
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/arduino/go-paths-helper
 license: gpl-2.0-or-later
 licenses:

--- a/.licenses/libraries-repository-engine/go/github.com/cloudflare/circl/internal/conv.dep.yml
+++ b/.licenses/libraries-repository-engine/go/github.com/cloudflare/circl/internal/conv.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/cloudflare/circl/internal/conv
 version: v1.6.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/cloudflare/circl/internal/conv
 license: bsd-3-clause
 licenses:

--- a/.licenses/libraries-repository-engine/go/github.com/pjbgf/sha1cd/internal.dep.yml
+++ b/.licenses/libraries-repository-engine/go/github.com/pjbgf/sha1cd/internal.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/pjbgf/sha1cd/internal
 version: v0.3.2
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/pjbgf/sha1cd/internal
 license: apache-2.0
 licenses:

--- a/.licenses/libraries-repository-engine/go/github.com/xanzy/ssh-agent.dep.yml
+++ b/.licenses/libraries-repository-engine/go/github.com/xanzy/ssh-agent.dep.yml
@@ -216,3 +216,4 @@ licenses:
     Version 2.0 (the "License"); you may not use this file except in compliance with
     the License. You may obtain a copy of the License at <http://www.apache.org/licenses/LICENSE-2.0>
 notices: []
+...

--- a/.licenses/libraries-repository-engine/go/github.com/xanzy/ssh-agent.dep.yml
+++ b/.licenses/libraries-repository-engine/go/github.com/xanzy/ssh-agent.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/xanzy/ssh-agent
 version: v0.3.3
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/xanzy/ssh-agent
 license: apache-2.0
 licenses:

--- a/.licenses/libraries-repository-engine/go/go.bug.st/relaxed-semver.dep.yml
+++ b/.licenses/libraries-repository-engine/go/go.bug.st/relaxed-semver.dep.yml
@@ -42,3 +42,4 @@ licenses:
     POSSIBILITY OF SUCH DAMAGE.
 
 notices: []
+...

--- a/.licenses/libraries-repository-engine/go/go.bug.st/relaxed-semver.dep.yml
+++ b/.licenses/libraries-repository-engine/go/go.bug.st/relaxed-semver.dep.yml
@@ -2,7 +2,7 @@
 name: go.bug.st/relaxed-semver
 version: v0.13.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/go.bug.st/relaxed-semver
 license: bsd-3-clause
 licenses:


### PR DESCRIPTION
The [**Licensed**](https://github.com/github/licensed) tool is used to check for incompatible licenses in the project dependencies. The tool relies on a cache of metadata stored in the repository.

An older version of **Licensed** was in use at the time the cache was established. There are some minor differences in the format of the metadata generated by the version of **Licensed** currently in use.

Even though there is no technical significance to the format differences, they are disruptive in that they result in irrelevant diffs in specific metadata files when they are regenerated after a dependency bump. Rather than dealing with these diffs over time, it will be best to instead update the metadata to the new format comprehensively.