### PR TITLE
Fix spurious unit test failure on Windows machines

### DIFF
--- a/internal/command/check-registry/check-registry_test.go
+++ b/internal/command/check-registry/check-registry_test.go
@@ -38,7 +38,7 @@ func TestRegistryValidation(t *testing.T) {
 	}
 	tests := []testcase{
 		{"EmptyArg", "", "registry data file argument testdata is a folder, not a file"},
-		{"NonExistentFile", "nonexistent.txt", "while loading registry data file: stat testdata/nonexistent.txt: no such file or directory"},
+		{"NonExistentFile", "nonexistent.txt", "while loading registry data file:"},
 		{"InvalidDataFormat", "invalid-data-format.txt", "while loading registry data file: invalid line format (3 fields are required): https://github.com/arduino-libraries/SD.git|Partner;SD"},
 		{"InvalidUrlFormat", "invalid-url-format.txt", "while filtering registry data file: Following URL are unknown or unsupported git repos:\nhttps://github.com/arduino-libraries/SD"},
 		{"MissingType", "no-type.txt", "invalid type '' used by library 'SD'"},
@@ -53,7 +53,7 @@ func TestRegistryValidation(t *testing.T) {
 			if test.ExpectedResult == "" {
 				require.NoError(t, err)
 			} else {
-				require.EqualError(t, err, test.ExpectedResult)
+				require.ErrorContains(t, err, test.ExpectedResult)
 			}
 		})
 	}


### PR DESCRIPTION
Although libraries-repository-engine is only used on a Linux machine, development of the project should be possible for contributors using any operating system.

Previously, the "TestRegistryValidation/NonExistentFile" unit test failed when ran on a Windows machine:

```
Running tool: C:\Users\per\sdk\go1.24.0\bin\go.exe test -timeout 30s -run ^TestRegistryValidation$ github.com/arduino/libraries-repository-engine/internal/command/check-registry

--- FAIL: TestRegistryValidation (0.00s)
    --- FAIL: TestRegistryValidation/NonExistentFile (0.00s)
        e:\git\arduino\libraries-repository-engine\internal\command\check-registry\check-registry_test.go:57:
            	Error Trace:	e:/git/arduino/libraries-repository-engine/internal/command/check-registry/check-registry_test.go:57
            	Error:      	Error message not equal:
            	            	expected: "while loading registry data file: stat testdata/nonexistent.txt: no such file or directory"
            	            	actual  : "while loading registry data file: CreateFile testdata\\nonexistent.txt: The system cannot find the file specified."
            	Test:       	TestRegistryValidation/NonExistentFile
FAIL
FAIL	github.com/arduino/libraries-repository-engine/internal/command/check-registry	0.227s
FAIL
```

The problem is that the Windows operating system generates a different error message than Linux and the test assertion contained the Linux-specific message content.

The fix is to change the assertion so that it only checks for the presence of a distinctive fragment of the error message which is universal.